### PR TITLE
fix: add app.getAppPath fallback; flag imported models

### DIFF
--- a/src/apps/desktop/src/main/index.ts
+++ b/src/apps/desktop/src/main/index.ts
@@ -41,15 +41,18 @@ function getAppIconPath(): string {
         ? [
             path.join(process.resourcesPath, 'icon.icns'),
             path.join(process.resourcesPath, 'app.asar', 'resources', 'icon.png'),
+            path.join(app.getAppPath(), 'resources', 'icon.icns'),
           ]
         : process.platform === 'win32'
           ? [
               path.join(process.resourcesPath, 'icon.ico'),
               path.join(process.resourcesPath, 'app.asar', 'resources', 'icon.ico'),
+              path.join(app.getAppPath(), 'resources', 'icon.ico'),
             ]
           : [
               path.join(process.resourcesPath, 'icon.png'),
               path.join(process.resourcesPath, 'app.asar', 'resources', 'icon.png'),
+              path.join(app.getAppPath(), 'resources', 'icon.png'),
             ]
     )
     : [

--- a/src/apps/desktop/src/main/index.ts
+++ b/src/apps/desktop/src/main/index.ts
@@ -55,6 +55,7 @@ function getAppIconPath(): string {
     : [
         path.join(__dirname, '..', '..', 'resources', 'icon.png'),
         path.join(__dirname, '..', '..', 'resources', 'icon.icns'),
+        path.join(app.getAppPath(), 'resources', 'icon.png'),
       ]
 
   for (const candidate of candidates) {

--- a/src/apps/desktop/src/main/tray.ts
+++ b/src/apps/desktop/src/main/tray.ts
@@ -9,6 +9,7 @@ function resolveResource(name: string): string {
     ? [
         path.join(process.resourcesPath, name),
         path.join(process.resourcesPath, 'app.asar', 'resources', name),
+        path.join(app.getAppPath(), 'resources', name),
       ]
     : [
         path.join(__dirname, '..', '..', 'resources', name),

--- a/src/apps/desktop/src/main/tray.ts
+++ b/src/apps/desktop/src/main/tray.ts
@@ -12,6 +12,7 @@ function resolveResource(name: string): string {
       ]
     : [
         path.join(__dirname, '..', '..', 'resources', name),
+        path.join(app.getAppPath(), 'resources', name),
       ]
   return candidates.find((c) => fs.existsSync(c)) ?? candidates[0]
 }

--- a/src/apps/web/src/components/OnboardingWizard.tsx
+++ b/src/apps/web/src/components/OnboardingWizard.tsx
@@ -733,8 +733,9 @@ export function OnboardingWizard({ onComplete }: Props) {
       setConfiguredModels((current) =>
         mergeConfiguredModels(current, imported),
       );
+      const importedIdSet = new Set(ids);
       setAvailableModels((current) =>
-        current.map((m) => (ids.includes(m.id) ? { ...m, configured: true } : m)),
+        current.map((m) => (importedIdSet.has(m.id) ? { ...m, configured: true } : m)),
       );
       setSelectedModelIds(new Set());
       setModelImportStatus("done");

--- a/src/apps/web/src/components/OnboardingWizard.tsx
+++ b/src/apps/web/src/components/OnboardingWizard.tsx
@@ -733,6 +733,9 @@ export function OnboardingWizard({ onComplete }: Props) {
       setConfiguredModels((current) =>
         mergeConfiguredModels(current, imported),
       );
+      setAvailableModels((current) =>
+        current.map((m) => (ids.includes(m.id) ? { ...m, configured: true } : m)),
+      );
       setSelectedModelIds(new Set());
       setModelImportStatus("done");
       setStep("appearance");


### PR DESCRIPTION
Update the web OnboardingWizard to mark available models as configured after importing, ensuring the UI reflects newly configured models.

Add app.getAppPath-based candidates when resolving resource paths in the desktop main and tray code so bundled/packaged installs can find icons/resources. 