### PR TITLE
build(desktop): add rpm package target

### DIFF
--- a/.github/workflows/build-desktop.yaml
+++ b/.github/workflows/build-desktop.yaml
@@ -161,6 +161,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Linux packaging dependencies
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm
+
       - name: Download sidecar binary
         uses: actions/download-artifact@v4
         with:
@@ -212,6 +218,7 @@ jobs:
             src/apps/desktop/release/*.zip
             src/apps/desktop/release/*.AppImage
             src/apps/desktop/release/*.deb
+            src/apps/desktop/release/*.rpm
             src/apps/desktop/release/*.exe
             src/apps/desktop/release/*.blockmap
             src/apps/desktop/release/latest*.yml
@@ -267,6 +274,7 @@ jobs:
             -name '*.zip' -o \
             -name '*.AppImage' -o \
             -name '*.deb' -o \
+            -name '*.rpm' -o \
             -name '*.exe' -o \
             -name '*.blockmap' -o \
             -name 'latest*.yml' \
@@ -447,7 +455,7 @@ jobs:
           - Windows：下载 `Arkloop-win-x64.exe`
           - macOS Apple Silicon：下载 `Arkloop-mac-arm64.dmg`
           - macOS Intel：下载 `Arkloop-mac-x64.dmg`
-          - Linux x64：下载 `Arkloop-linux-amd64.deb` 或 `Arkloop-linux-x86_64.AppImage`
+          - Linux x64：下载 `Arkloop-linux-amd64.deb`、`Arkloop-linux-x86_64.rpm` 或 `Arkloop-linux-x86_64.AppImage`
 
           ## 说明
           EOF

--- a/src/apps/desktop/electron-builder.yml
+++ b/src/apps/desktop/electron-builder.yml
@@ -60,6 +60,7 @@ linux:
   target:
     - AppImage
     - deb
+    - rpm
   icon: resources/icon.png
   extraResources:
     - from: sidecar-bin/desktop-linux-${arch}

--- a/src/apps/desktop/package.json
+++ b/src/apps/desktop/package.json
@@ -26,6 +26,7 @@
     "dist:mac:arm64": "pnpm build:web && pnpm build:electron && node scripts/build-sidecar.mjs --platform darwin --arch arm64 && electron-builder --mac --arm64",
     "dist:mac:x64": "pnpm build:web && pnpm build:electron && node scripts/build-sidecar.mjs --platform darwin --arch x64 && electron-builder --mac --x64",
     "dist:linux": "pnpm build:web && pnpm build:electron && pnpm build:sidecar && electron-builder --linux",
+    "dist:linux:rpm": "pnpm build:web && pnpm build:electron && pnpm build:sidecar && electron-builder --linux rpm",
     "dist:win": "pnpm build:web && pnpm build:electron && node scripts/build-sidecar.mjs --platform win32 --arch x64 && electron-builder --win",
     "dist:all": "pnpm build:web && pnpm build:electron && pnpm build:sidecar:all && electron-builder -mwl",
     "type-check": "tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.preload.json --noEmit"


### PR DESCRIPTION
## Summary
- add `rpm` to desktop Linux packaging targets in `electron-builder`
- upload and publish `.rpm` artifacts in the desktop release workflow
- install Linux RPM tooling in CI and add a local `dist:linux:rpm` script

## Verification
- `pnpm --filter @arkloop/desktop type-check`
- `git diff --check`
- `GOTOOLCHAIN=auto pnpm --filter @arkloop/desktop dist:linux:rpm`