### PR TITLE
fix(desktop): avoid RPM build-id conflicts

### DIFF
--- a/src/apps/desktop/electron-builder.yml
+++ b/src/apps/desktop/electron-builder.yml
@@ -66,6 +66,10 @@ linux:
     - from: sidecar-bin/desktop-linux-${arch}
       to: sidecar/desktop
 
+rpm:
+  fpm:
+    - --rpm-rpmbuild-define=_build_id_links none
+
 win:
   artifactName: "${productName}-win-${arch}.${ext}"
   target:


### PR DESCRIPTION
## Summary
- disable `rpmbuild` build-id link generation for the desktop RPM package
- prevent install conflicts with other Electron apps that ship overlapping native libraries on RPM-based systems

## Validation
- `pnpm exec electron-builder --linux rpm --publish never -c.extraMetadata.version=26.4.22`
- `rpm -qlp release/Arkloop-linux-x86_64.rpm | rg '/usr/lib/\.build-id/'` produced no output