### PR TITLE
feat(desktop): add windows titlebar

### DIFF
--- a/src/apps/desktop/src/main/index.ts
+++ b/src/apps/desktop/src/main/index.ts
@@ -346,6 +346,7 @@ function attachRendererContextMenu(win: BrowserWindow): void {
 function createWindow(): BrowserWindow {
   const config = loadConfig()
   const iconPath = getAppIconPath()
+  const isWindows = process.platform === 'win32'
 
   const win = new BrowserWindow({
     width: config.window.width,
@@ -360,6 +361,7 @@ function createWindow(): BrowserWindow {
       nodeIntegration: false,
       sandbox: true,
     },
+    frame: isWindows ? false : undefined,
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     trafficLightPosition: { x: 12, y: 12 },
     ...(process.platform === 'linux' || process.platform === 'win32' ? { icon: iconPath } : {}),
@@ -390,6 +392,12 @@ function createWindow(): BrowserWindow {
   win.once('ready-to-show', () => {
     win.show()
   })
+
+  const syncMaximizedState = () => {
+    win.webContents.send('arkloop:window:maximized-changed', win.isMaximized())
+  }
+  win.on('maximize', syncMaximizedState)
+  win.on('unmaximize', syncMaximizedState)
 
   win.webContents.setWindowOpenHandler(({ url }) => {
     if (parseHttpUrl(url)) {

--- a/src/apps/desktop/src/main/ipc.ts
+++ b/src/apps/desktop/src/main/ipc.ts
@@ -409,6 +409,29 @@ export function registerIpcHandlers(
     }
   })
 
+  ipcMain.handle('arkloop:window:minimize', () => {
+    getWindow()?.minimize()
+  })
+
+  ipcMain.handle('arkloop:window:toggle-maximize', () => {
+    const win = getWindow()
+    if (!win) return { maximized: false }
+    if (win.isMaximized()) {
+      win.unmaximize()
+    } else {
+      win.maximize()
+    }
+    return { maximized: win.isMaximized() }
+  })
+
+  ipcMain.handle('arkloop:window:close', () => {
+    getWindow()?.close()
+  })
+
+  ipcMain.handle('arkloop:window:is-maximized', () => {
+    return getWindow()?.isMaximized() ?? false
+  })
+
   ipcMain.handle('arkloop:logs:dir', () => {
     return getDesktopLogDir()
   })

--- a/src/apps/desktop/src/preload/index.ts
+++ b/src/apps/desktop/src/preload/index.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 
 export type ConnectionMode = 'local' | 'saas' | 'self-hosted'
 export type LocalPortMode = 'auto' | 'manual'
+export type DesktopPlatform = 'win32' | 'darwin' | 'linux' | string
 
 export type FetchProvider = 'none' | 'jina' | 'basic' | 'firecrawl'
 export type SearchProvider = 'none' | 'duckduckgo' | 'tavily' | 'searxng'
@@ -320,6 +321,13 @@ export type ArkloopDesktopApi = {
     getOsUsername: () => Promise<string>
     openExternal: (url: string) => Promise<void>
   }
+  window: {
+    minimize: () => Promise<void>
+    toggleMaximize: () => Promise<{ maximized: boolean }>
+    close: () => Promise<void>
+    isMaximized: () => Promise<boolean>
+    onMaximizedChanged: (callback: (maximized: boolean) => void) => () => void
+  }
   logs: {
     getDir: () => Promise<string>
     getFiles: () => Promise<{ main: string; sidecar: string }>
@@ -371,10 +379,12 @@ contextBridge.exposeInMainWorld('__ARKLOOP_DESKTOP__', {
   bridgeBaseUrl: bridgeBaseUrlSnapshot,
   accessToken: config.desktopAccessToken ?? '',
   mode: configSnapshot.mode,
+  platform: process.platform,
   getApiBaseUrl: () => getCurrentApiBaseUrl(),
   getBridgeBaseUrl: () => bridgeBaseUrlSnapshot,
   getAccessToken: () => config.desktopAccessToken ?? '',
   getMode: () => configSnapshot.mode,
+  getPlatform: () => process.platform,
 })
 
 ipcRenderer.on('arkloop:config:changed', (_event: Electron.IpcRendererEvent, nextConfig: AppConfig) => {
@@ -496,6 +506,18 @@ const api: ArkloopDesktopApi = {
     quit: () => ipcRenderer.invoke('arkloop:app:quit'),
     getOsUsername: () => ipcRenderer.invoke('arkloop:app:os-username'),
     openExternal: (url: string) => ipcRenderer.invoke('arkloop:app:open-external', url),
+  },
+
+  window: {
+    minimize: () => ipcRenderer.invoke('arkloop:window:minimize'),
+    toggleMaximize: () => ipcRenderer.invoke('arkloop:window:toggle-maximize'),
+    close: () => ipcRenderer.invoke('arkloop:window:close'),
+    isMaximized: () => ipcRenderer.invoke('arkloop:window:is-maximized'),
+    onMaximizedChanged: (callback) => {
+      const handler = (_event: Electron.IpcRendererEvent, maximized: boolean) => callback(maximized)
+      ipcRenderer.on('arkloop:window:maximized-changed', handler)
+      return () => ipcRenderer.removeListener('arkloop:window:maximized-changed', handler)
+    },
   },
 
   logs: {

--- a/src/apps/shared/src/desktop.ts
+++ b/src/apps/shared/src/desktop.ts
@@ -1,5 +1,6 @@
 export type ConnectionMode = 'local' | 'saas' | 'self-hosted'
 export type LocalPortMode = 'auto' | 'manual'
+export type DesktopPlatform = 'win32' | 'darwin' | 'linux' | string
 
 export type FetchProvider = 'none' | 'jina' | 'basic' | 'firecrawl'
 export type SearchProvider = 'none' | 'duckduckgo' | 'tavily' | 'searxng'
@@ -124,10 +125,12 @@ type DesktopInfo = {
   bridgeBaseUrl?: string
   accessToken?: string
   mode?: ConnectionMode
+  platform?: DesktopPlatform
   getApiBaseUrl?: () => string
   getBridgeBaseUrl?: () => string
   getAccessToken?: () => string
   getMode?: () => ConnectionMode
+  getPlatform?: () => DesktopPlatform
 }
 
 export type UpdaterComponentStatus = {
@@ -218,6 +221,13 @@ export type ArkloopDesktopApi = {
     getVersion: () => Promise<string>
     quit: () => Promise<void>
     getOsUsername?: () => Promise<string>
+  }
+  window?: {
+    minimize: () => Promise<void>
+    toggleMaximize: () => Promise<{ maximized: boolean }>
+    close: () => Promise<void>
+    isMaximized: () => Promise<boolean>
+    onMaximizedChanged: (callback: (maximized: boolean) => void) => () => void
   }
   logs?: {
     getDir: () => Promise<string>
@@ -346,6 +356,14 @@ export function getDesktopMode(): ConnectionMode | null {
     return info.getMode() ?? null
   }
   return info?.mode ?? null
+}
+
+export function getDesktopPlatform(): DesktopPlatform | null {
+  const info = getDesktopInfo()
+  if (typeof info?.getPlatform === 'function') {
+    return info.getPlatform() ?? null
+  }
+  return info?.platform ?? null
 }
 
 export function getDesktopAccessToken(): string | null {

--- a/src/apps/shared/src/index.ts
+++ b/src/apps/shared/src/index.ts
@@ -69,8 +69,8 @@ export type {
 export { SettingsModal } from './components/SettingsModal'
 export type { SettingsModalTranslations } from './components/SettingsModal'
 
-export { isDesktop, getDesktopApi, getDesktopMode, isLocalMode } from './desktop'
-export type { ConnectionMode, ArkloopDesktopApi } from './desktop'
+export { isDesktop, getDesktopApi, getDesktopMode, getDesktopPlatform, isLocalMode } from './desktop'
+export type { ConnectionMode, DesktopPlatform, ArkloopDesktopApi } from './desktop'
 
 export { Badge } from './components/Badge'
 export type { BadgeVariant } from './components/Badge'

--- a/src/apps/web/src/components/DesktopTitleBar.tsx
+++ b/src/apps/web/src/components/DesktopTitleBar.tsx
@@ -1,6 +1,17 @@
 import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronLeft, ChevronRight, PanelLeftClose, PanelLeftOpen, Glasses, ArrowUp } from 'lucide-react'
-import { isDesktop } from '@arkloop/shared/desktop'
+import {
+  ArrowUp,
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  Glasses,
+  Minus,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Square,
+  X,
+} from 'lucide-react'
+import { getDesktopApi, getDesktopPlatform, isDesktop } from '@arkloop/shared/desktop'
 import type { AppUpdaterState } from '@arkloop/shared/desktop'
 import { SpinnerIcon } from '@arkloop/shared/components/auth-ui'
 import { Button } from '@arkloop/shared'
@@ -13,6 +24,7 @@ import { beginPerfTrace, endPerfTrace } from '../perfDebug'
 import { secondaryButtonSmCls, secondaryButtonBorderStyle } from './buttonStyles'
 
 export const DESKTOP_TITLEBAR_HEIGHT = 44
+const WINDOWS_TITLEBAR_HEIGHT = 44
 
 type Props = {
   sidebarCollapsed: boolean
@@ -53,6 +65,36 @@ export function DesktopTitleBar({
   const popoverRef = useRef<HTMLDivElement>(null)
   const [updatePopoverOpen, setUpdatePopoverOpen] = useState(false)
   const [updatePopoverPosition, setUpdatePopoverPosition] = useState<{ top: number; right: number }>({ top: 50, right: 12 })
+  const [windowMaximized, setWindowMaximized] = useState(false)
+  const desktopPlatform = getDesktopPlatform()
+  const platformName = (desktopPlatform ?? navigator.platform).toLowerCase()
+  const isMac = desktopPlatform === 'darwin' || (!desktopPlatform && platformName.includes('mac'))
+  const isWindows = desktopPlatform === 'win32' || (!desktopPlatform && platformName.includes('win'))
+  const titleBarHeight = isWindows ? WINDOWS_TITLEBAR_HEIGHT : DESKTOP_TITLEBAR_HEIGHT
+
+  useEffect(() => {
+    if (!isWindows) return
+    const api = getDesktopApi()
+    void api?.window?.isMaximized().then(setWindowMaximized).catch(() => {})
+    return api?.window?.onMaximizedChanged?.(setWindowMaximized)
+  }, [isWindows])
+
+  const handleWindowMinimize = useCallback(() => {
+    const request = getDesktopApi()?.window?.minimize()
+    void request?.catch(() => {})
+  }, [])
+
+  const handleWindowMaximize = useCallback(() => {
+    const request = getDesktopApi()?.window?.toggleMaximize()
+    void request
+      ?.then((result) => setWindowMaximized(result.maximized))
+      .catch(() => {})
+  }, [])
+
+  const handleWindowClose = useCallback(() => {
+    const request = getDesktopApi()?.window?.close()
+    void request?.catch(() => {})
+  }, [])
 
   // 检查是否跳过了当前版本
   const isVersionSkipped = useMemo(() => {
@@ -97,29 +139,32 @@ export function DesktopTitleBar({
 
   if (!isDesktop()) return null
 
-  const isMac = navigator.platform.toLowerCase().includes('mac')
-
   const btnCls = [
     'flex h-8 w-8 items-center justify-center rounded-md',
     'text-[var(--c-text-tertiary)] transition-colors',
-    'hover:bg-[var(--c-bg-deep)] hover:text-[var(--c-text-secondary)]',
+    isWindows
+      ? 'hover:bg-[var(--title-btn-hover)] hover:text-[var(--c-text-primary)]'
+      : 'hover:bg-[var(--c-bg-deep)] hover:text-[var(--c-text-secondary)]',
   ].join(' ')
 
   return (
     <div
-      className="relative flex shrink-0 items-center"
+      className="relative grid shrink-0 items-center"
       style={{
-        height: DESKTOP_TITLEBAR_HEIGHT,
-        paddingLeft: isMac ? '76px' : '16px',
-        paddingRight: '12px',
-        background: 'var(--c-bg-sidebar)',
+        height: titleBarHeight,
+        gridTemplateColumns: 'minmax(0, 1fr) auto minmax(0, 1fr)',
+        paddingLeft: isMac ? '76px' : isWindows ? '12px' : '16px',
+        paddingRight: isWindows ? 0 : '12px',
+        background: isWindows
+          ? 'color-mix(in srgb, var(--c-bg-sidebar) 92%, var(--c-bg-page))'
+          : 'var(--c-bg-sidebar)',
         borderBottom: '0.5px solid var(--c-border-subtle)',
         WebkitAppRegion: 'drag',
       } as React.CSSProperties}
     >
-      {/* sidebar toggle + back/forward — nudged 1px down to align with macOS traffic lights */}
+      {/* sidebar and history controls */}
       <div
-        className="flex items-center gap-1 self-start pt-[6px]"
+        className={isWindows ? 'flex min-w-0 items-center gap-1.5 justify-self-start' : 'flex min-w-0 items-center gap-1 self-start justify-self-start pt-[6px]'}
         style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
         <button
@@ -154,9 +199,9 @@ export function DesktopTitleBar({
         </button>
       </div>
 
-      {/* ModeSwitch centered */}
+      {/* centered mode switch */}
       <div
-        className="absolute left-1/2 -translate-x-1/2 translate-y-px"
+        className="min-w-0 translate-y-px justify-self-center"
         style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
         <ModeSwitch
@@ -167,39 +212,51 @@ export function DesktopTitleBar({
         />
       </div>
 
-      {/* Right side: always no-drag to prevent drag region from blocking right-side panels */}
+      {/* app actions and window controls */}
       <div
-        className="ml-auto flex items-center justify-end"
-        style={{ WebkitAppRegion: 'no-drag', minWidth: '300px' } as React.CSSProperties}
+        className={isWindows ? 'flex min-w-0 items-stretch justify-end self-stretch justify-self-end' : 'flex min-w-0 items-center justify-end justify-self-end'}
+        style={{
+          WebkitAppRegion: 'no-drag',
+        } as React.CSSProperties}
       >
-        {showIncognitoToggle && onTogglePrivateMode && (
-          <button
-            onClick={onTogglePrivateMode}
-            title={t.toggleIncognito}
-            className={[
-              'flex h-8 w-8 items-center justify-center rounded-md transition-colors',
-              isPrivateMode
-                ? 'bg-[var(--c-bg-deep)] text-[var(--c-text-primary)]'
-                : 'text-[var(--c-text-tertiary)] hover:bg-[var(--c-bg-deep)] hover:text-[var(--c-text-secondary)]',
-            ].join(' ')}
-          >
-            <Glasses size={17} />
-          </button>
-        )}
-        {hasComponentUpdates && onCheckAppUpdate && (
-          <button
-            ref={updateBtnRef}
-            onClick={togglePopover}
-            title={isVersionSkipped ? t.updateSkipped : t.componentUpdatesAvailable}
-            className={`relative flex h-8 w-8 items-center justify-center rounded-md transition-colors hover:bg-[var(--c-bg-deep)] ${
-              isVersionSkipped ? 'text-[var(--c-text-muted)]' : 'text-[var(--c-accent)]'
-            }`}
-          >
-            <ArrowUp size={16} />
-            {!isVersionSkipped && (
-              <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-[var(--c-accent)]" />
-            )}
-          </button>
+        <div className={isWindows ? 'flex items-center justify-end gap-1 pr-2' : 'flex items-center justify-end'}>
+          {showIncognitoToggle && onTogglePrivateMode && (
+            <button
+              onClick={onTogglePrivateMode}
+              title={t.toggleIncognito}
+              className={[
+                'flex h-8 w-8 items-center justify-center rounded-md transition-colors',
+                isPrivateMode
+                  ? 'bg-[var(--c-bg-deep)] text-[var(--c-text-primary)]'
+                  : 'text-[var(--c-text-tertiary)] hover:bg-[var(--c-bg-deep)] hover:text-[var(--c-text-secondary)]',
+              ].join(' ')}
+            >
+              <Glasses size={17} />
+            </button>
+          )}
+          {hasComponentUpdates && onCheckAppUpdate && (
+            <button
+              ref={updateBtnRef}
+              onClick={togglePopover}
+              title={isVersionSkipped ? t.updateSkipped : t.componentUpdatesAvailable}
+              className={`relative flex h-8 w-8 items-center justify-center rounded-md transition-colors hover:bg-[var(--c-bg-deep)] ${
+                isVersionSkipped ? 'text-[var(--c-text-muted)]' : 'text-[var(--c-accent)]'
+              }`}
+            >
+              <ArrowUp size={16} />
+              {!isVersionSkipped && (
+                <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-[var(--c-accent)]" />
+              )}
+            </button>
+          )}
+        </div>
+        {isWindows && (
+          <WindowsWindowControls
+            maximized={windowMaximized}
+            onMinimize={handleWindowMinimize}
+            onMaximize={handleWindowMaximize}
+            onClose={handleWindowClose}
+          />
         )}
         {updatePopoverOpen && <UpdatePopover
           ref={popoverRef}
@@ -211,6 +268,66 @@ export function DesktopTitleBar({
           onClose={() => setUpdatePopoverOpen(false)}
         />}
       </div>
+    </div>
+  )
+}
+
+type WindowsWindowControlsProps = {
+  maximized: boolean
+  onMinimize: () => void
+  onMaximize: () => void
+  onClose: () => void
+}
+
+function WindowsWindowControls({
+  maximized,
+  onMinimize,
+  onMaximize,
+  onClose,
+}: WindowsWindowControlsProps) {
+  const buttonCls = [
+    'flex h-full w-[46px] items-center justify-center',
+    'text-[var(--c-text-secondary)] transition-colors',
+    'hover:bg-[var(--title-btn-hover)] hover:text-[var(--c-text-primary)]',
+  ].join(' ')
+
+  return (
+    <div className="flex h-full items-stretch">
+      <button
+        type="button"
+        title="Minimize"
+        aria-label="Minimize"
+        className={buttonCls}
+        onClick={onMinimize}
+      >
+        <Minus size={15} strokeWidth={1.8} />
+      </button>
+      <button
+        type="button"
+        title={maximized ? 'Restore' : 'Maximize'}
+        aria-label={maximized ? 'Restore' : 'Maximize'}
+        className={buttonCls}
+        onClick={onMaximize}
+      >
+        {maximized ? (
+          <Copy size={13} strokeWidth={1.7} />
+        ) : (
+          <Square size={12} strokeWidth={1.8} />
+        )}
+      </button>
+      <button
+        type="button"
+        title="Close"
+        aria-label="Close"
+        className={[
+          'flex h-full w-[46px] items-center justify-center',
+          'text-[var(--c-text-secondary)] transition-colors',
+          'hover:bg-[var(--c-window-close-hover)] hover:text-white',
+        ].join(' ')}
+        onClick={onClose}
+      >
+        <X size={15} strokeWidth={1.8} />
+      </button>
     </div>
   )
 }

--- a/src/apps/web/src/index.css
+++ b/src/apps/web/src/index.css
@@ -127,6 +127,7 @@ button:not(:disabled) {
   --c-attachment-shimmer-mid: #454542;
   --title-btn-dim: rgba(255, 255, 255, 0.04);
   --title-btn-hover: rgba(255, 255, 255, 0.09);
+  --c-window-close-hover: #c42b1c;
   --c-sidebar-btn-hover: #000000;
   --c-mode-switch-track: rgba(255, 255, 255, 0.06);
   --c-mode-switch-border: rgba(255, 255, 255, 0.08);
@@ -269,6 +270,7 @@ button:not(:disabled) {
     --c-attachment-shimmer-mid: #D8D8D6;
     --title-btn-dim: rgba(0, 0, 0, 0.06);
     --title-btn-hover: rgba(0, 0, 0, 0.10);
+    --c-window-close-hover: #c42b1c;
     --c-sidebar-btn-hover: rgba(0, 0, 0, 0.12);
     --c-mode-switch-track: rgba(0, 0, 0, 0.05);
     --c-mode-switch-border: rgba(0, 0, 0, 0.08);
@@ -392,6 +394,7 @@ button:not(:disabled) {
   --c-attachment-shimmer-mid: #D8D8D6;
   --title-btn-dim: rgba(0, 0, 0, 0.06);
   --title-btn-hover: rgba(0, 0, 0, 0.10);
+  --c-window-close-hover: #c42b1c;
   --c-sidebar-btn-hover: rgba(0, 0, 0, 0.12);
   --c-mode-switch-track: rgba(0, 0, 0, 0.05);
   --c-mode-switch-border: rgba(0, 0, 0, 0.08);


### PR DESCRIPTION
## Summary
- make the Windows desktop shell frameless while leaving macOS and Linux window behavior unchanged
- expose desktop window controls through preload/shared APIs
- update the desktop title bar to use responsive three-column layout and Windows-style caption buttons

## Verification
- pnpm -C src/apps/web type-check
- pnpm -C src/apps/desktop type-check
- pnpm -C src/apps/desktop build:web
- pnpm -C src/apps/desktop build:electron