### PR TITLE
fix(localshell): resolveProcessShellCommand on Windows returns cmd.exe

### DIFF
--- a/src/services/worker/internal/tools/localshell/controller.go
+++ b/src/services/worker/internal/tools/localshell/controller.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -767,6 +768,9 @@ func buildOutputRef(processRef string, cursor uint64, next uint64) string {
 }
 
 func resolveProcessShellCommand(command string) (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd.exe", []string{"/c", command}
+	}
 	if _, err := os.Stat("/bin/bash"); err == nil {
 		return "/bin/bash", []string{"--noprofile", "--norc", "-lc", command}
 	}


### PR DESCRIPTION
On Windows, resolveProcessShellCommand was unconditionally returning Unix shell paths (/bin/bash or /bin/sh), causing all exec_command calls to fail with "exec: /bin/sh: executable file not found".

This fix adds a runtime.GOOS check at the start of the function to return "cmd.exe" with /c flag on Windows, matching the behavior already present in the shell_windows.go build helper.

Fixes: exec_command Windows failure