### PR TITLE
fix(desktop): conditionally apply darwin ldflags in dev script

### DIFF
--- a/src/apps/desktop/scripts/dev.mjs
+++ b/src/apps/desktop/scripts/dev.mjs
@@ -90,7 +90,8 @@ async function main() {
 
   console.log('building desktop sidecar...')
   mkdirSync(resolve(desktopBin, '..'), { recursive: true })
-  await runStep('go', ['build', '-tags', 'desktop', '-ldflags', '-extldflags=-Wl,-no_warn_duplicate_libraries', '-o', desktopBin, './src/services/desktop/cmd/desktop'], {
+  const darwinLdflags = process.platform === 'darwin' ? ['-ldflags', '-extldflags=-Wl,-no_warn_duplicate_libraries'] : []
+  await runStep('go', ['build', '-tags', 'desktop', ...darwinLdflags, '-o', desktopBin, './src/services/desktop/cmd/desktop'], {
     cwd: workspaceRoot,
   })
 


### PR DESCRIPTION
## 问题

`dev.mjs` 中 `-ldflags -extldflags=-Wl,-no_warn_duplicate_libraries` 无条件传入 `go build`，该参数仅适用于 macOS，在 Windows 上使用会导致报错。

## 修改

仅在 `process.platform === 'darwin'` 时传入 ldflags，其他平台跳过。

## 验证

- [x] Windows 上 `pnpm dev:desktop` 正常构建
- [ ] macOS 上 `pnpm dev:desktop` 正常构建（无 duplicate library 警告）