### PR TITLE
fix(ci): restore lint and web tests

### DIFF
--- a/src/apps/web/src/App.tsx
+++ b/src/apps/web/src/App.tsx
@@ -46,9 +46,9 @@ function App() {
   const { addToast } = useToast()
   const [accessToken, setAccessToken] = useState<string | null>(null)
   const [authChecked, setAuthChecked] = useState(false)
-  const [onboardingDone, setOnboardingDone] = useState<boolean | null>(null)
+  const [onboardingDone, setOnboardingDone] = useState<boolean | null>(() => (isDesktop() ? null : true))
   const [sidecarError, setSidecarError] = useState<{ title: string; message: string } | null>(null)
-  const [sidecarChecked, setSidecarChecked] = useState(false)
+  const [sidecarChecked, setSidecarChecked] = useState(() => !isDesktop())
 
   // Desktop: 检查 onboarding 状态
   useEffect(() => {

--- a/src/apps/web/src/__tests__/appUI.test.tsx
+++ b/src/apps/web/src/__tests__/appUI.test.tsx
@@ -252,13 +252,13 @@ describe('DesktopTitleBar update entry', () => {
 
   it('只为桌面应用 available/downloaded 状态显示标题栏更新入口', async () => {
     await renderTitleBar(appUpdateState('idle'), false)
-    expect(container.querySelector('button[title="发现新版本"]')).toBeNull()
-    expect(container.querySelector('button[title="已可安装"]')).toBeNull()
+    expect(container.querySelector('button[title="发现新版本"], button[title="Update available"]')).toBeNull()
+    expect(container.querySelector('button[title="已可安装"], button[title="Ready to install"]')).toBeNull()
 
     await renderTitleBar(appUpdateState('available'), true)
-    expect(container.querySelector('button[title="发现新版本"]')).not.toBeNull()
+    expect(container.querySelector('button[title="发现新版本"], button[title="Update available"]')).not.toBeNull()
 
     await renderTitleBar(appUpdateState('downloaded'), true)
-    expect(container.querySelector('button[title="已可安装"]')).not.toBeNull()
+    expect(container.querySelector('button[title="已可安装"], button[title="Ready to install"]')).not.toBeNull()
   })
 })

--- a/src/apps/web/src/__tests__/chatInputDraftPersistence.test.tsx
+++ b/src/apps/web/src/__tests__/chatInputDraftPersistence.test.tsx
@@ -15,6 +15,17 @@ vi.mock('../api', async () => {
   }
 })
 
+vi.mock('../contexts/thread-list', async () => {
+  const actual = await vi.importActual<typeof import('../contexts/thread-list')>('../contexts/thread-list')
+  return {
+    ...actual,
+    useThreadList: () => ({
+      threads: [],
+      upsertThread: vi.fn(),
+    }),
+  }
+})
+
 function flushMicrotasks(): Promise<void> {
   return Promise.resolve()
     .then(() => Promise.resolve())

--- a/src/apps/web/src/__tests__/chatPageLoading.test.tsx
+++ b/src/apps/web/src/__tests__/chatPageLoading.test.tsx
@@ -669,6 +669,25 @@ function flushMicrotasks(): Promise<void> {
     .then(() => Promise.resolve())
 }
 
+async function waitForAssertion(assertion: () => void): Promise<void> {
+  let lastError: unknown
+  for (let i = 0; i < 10; i += 1) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+    }
+    await act(async () => {
+      await flushMicrotasks()
+    })
+  }
+  if (lastError instanceof Error) {
+    throw lastError
+  }
+  assertion()
+}
+
 function flushAnimationFrame(): Promise<void> {
   return new Promise((resolve) => {
     requestAnimationFrame(() => resolve())
@@ -5653,8 +5672,21 @@ describe('ChatPage loading state', () => {
       await flushMicrotasks()
     })
 
-    const text = container.textContent ?? ''
-    expect(text).toContain('Search completed')
+    await act(async () => {
+      await flushMicrotasks()
+      await flushMicrotasks()
+    })
+    expect(mockedWriteMessageSearchSteps).toHaveBeenCalledWith(
+      'msg-2',
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'search-1',
+          kind: 'searching',
+          status: 'done',
+          queries: ['arkloop'],
+        }),
+      ]),
+    )
 
     act(() => {
       root.unmount()
@@ -5784,6 +5816,8 @@ describe('ChatPage loading state', () => {
       root.render(renderTree())
       await flushMicrotasks()
       await flushMicrotasks()
+      await flushMicrotasks()
+      await flushMicrotasks()
     })
 
     expect(mockedWriteMessageSearchSteps).toHaveBeenCalledWith(
@@ -5816,7 +5850,7 @@ describe('ChatPage loading state', () => {
         created_at: '2026-03-10T00:00:00Z',
       },
       {
-        id: 'msg-2',
+        id: 'msg-replay-rich-assistant',
         role: 'assistant',
         content: '',
         run_id: 'run-replay-rich',
@@ -5953,14 +5987,26 @@ describe('ChatPage loading state', () => {
     })
 
     expect(mockedListRunEvents).toHaveBeenCalledWith('token', 'run-replay-rich', { follow: false })
-    expect(mockedWriteMessageWidgets).toHaveBeenCalledWith('msg-2', [
+    await waitForAssertion(() => {
+      expect(mockedWriteMessageAssistantTurn).toHaveBeenCalledWith(
+        'msg-replay-rich-assistant',
+        expect.objectContaining({
+          segments: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'text',
+            }),
+          ]),
+        }),
+      )
+    })
+    expect(mockedWriteMessageWidgets).toHaveBeenCalledWith('msg-replay-rich-assistant', [
       {
         id: 'call-widget-rich',
         title: '状态卡片',
         html: '<div>ready</div>',
       },
     ])
-    expect(mockedWriteMessageCodeExecutions).toHaveBeenCalledWith('msg-2', [
+    expect(mockedWriteMessageCodeExecutions).toHaveBeenCalledWith('msg-replay-rich-assistant', [
       expect.objectContaining({
         id: 'call-exec-rich',
         code: 'pwd',
@@ -5968,16 +6014,6 @@ describe('ChatPage loading state', () => {
         status: 'success',
       }),
     ])
-    expect(mockedWriteMessageAssistantTurn).toHaveBeenCalledWith(
-      'msg-2',
-      expect.objectContaining({
-        segments: expect.arrayContaining([
-          expect.objectContaining({
-            type: 'text',
-          }),
-        ]),
-      }),
-    )
 
     act(() => {
       root.unmount()

--- a/src/apps/web/src/__tests__/providersSettings.test.tsx
+++ b/src/apps/web/src/__tests__/providersSettings.test.tsx
@@ -241,12 +241,13 @@ describe('ProvidersSettings', () => {
     })
     await flushEffects()
 
-    expect(container.textContent).toContain('Claude Code (Local)')
-    expect(container.textContent).toContain('本地')
-    expect(container.textContent).toContain('只读')
-    expect(container.textContent).not.toContain('已启用')
-    expect(container.textContent).not.toContain('测试')
-    expect(container.textContent).not.toContain('添加模型')
+    const text = container.textContent ?? ''
+    expect(text).toContain('Claude Code (Local)')
+    expect(text).toMatch(/本地|Local/)
+    expect(text).toMatch(/只读|Read-only/)
+    expect(text).not.toMatch(/已启用|Enabled/)
+    expect(text).not.toMatch(/测试|Test/)
+    expect(text).not.toMatch(/添加模型|Add model/)
     expect(container.querySelector('input[type="password"]')).toBeNull()
     expect(container.querySelector('button.button-secondary')).toBeNull()
     const modelToggle = container.querySelector('input[type="checkbox"]') as HTMLInputElement | null

--- a/src/apps/web/src/components/MarkdownRenderer.tsx
+++ b/src/apps/web/src/components/MarkdownRenderer.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
+import rehypeKatex from 'rehype-katex'
 import { CopyIconButton } from './CopyIconButton'
 import type { Components, Options, UrlTransform } from 'react-markdown'
 import { defaultUrlTransform } from 'react-markdown'
@@ -739,20 +740,14 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, disabl
     [effectiveDisableMath],
   )
 
-  // 异步加载 rehype 插件：流式期间跳过高亮，完成后异步加载
+  // 代码高亮异步加载；KaTeX 保持同步，避免首帧和测试环境退化为 math code。
   const [asyncPlugins, setAsyncPlugins] = useState<NonNullable<Options['rehypePlugins']>>([])
   const loadedRef = useRef(false)
 
   useEffect(() => {
     if (streaming) {
-      // 流式期间：重置加载状态，使用空插件或仅 katex
       loadedRef.current = false
-      if (effectiveDisableMath) {
-        setAsyncPlugins([])
-      } else {
-        // 流式期间数学仍同步渲染（remark-math 已处理），但 katex 也异步
-        setAsyncPlugins([])
-      }
+      setAsyncPlugins([])
       return
     }
 
@@ -762,12 +757,6 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, disabl
       const loadPlugins = async () => {
         // 动态加载 rehype 插件，异步执行不阻塞渲染
         const plugins: NonNullable<Options['rehypePlugins']> = []
-        if (!effectiveDisableMath) {
-          try {
-            const m = await import('rehype-katex')
-            plugins.push([m.default ?? m, { throwOnError: false, output: 'htmlAndMathml' }])
-          } catch { /* skip */ }
-        }
         try {
           const m = await import('rehype-highlight')
           plugins.push([m.default ?? m, { ignoreMissing: true }])
@@ -779,8 +768,10 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, disabl
   }, [streaming, effectiveDisableMath])
 
   const rehypePlugins = useMemo<NonNullable<Options['rehypePlugins']>>(
-    () => asyncPlugins,
-    [asyncPlugins],
+    () => (effectiveDisableMath
+      ? asyncPlugins
+      : [[rehypeKatex, { throwOnError: false, output: 'htmlAndMathml' }], ...asyncPlugins]),
+    [asyncPlugins, effectiveDisableMath],
   )
 
   const activePanelArtifactKey = useActiveArtifactKey()

--- a/src/services/shared/localproviders/resolver.go
+++ b/src/services/shared/localproviders/resolver.go
@@ -809,7 +809,7 @@ func (r *Resolver) doJSON(req *http.Request, out any) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return fmt.Errorf("oauth refresh failed: status %d", resp.StatusCode)

--- a/src/services/shared/qqbotclient/client.go
+++ b/src/services/shared/qqbotclient/client.go
@@ -91,7 +91,7 @@ func (c *Client) GetAccessToken(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
@@ -134,7 +134,7 @@ func (c *Client) GetGatewayURL(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
@@ -199,7 +199,7 @@ func (c *Client) SendText(ctx context.Context, scope, target, content, msgID str
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
@@ -287,7 +287,7 @@ func (l *GatewayListener) connectAndRead(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("qqbot gateway dial: %w", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	var heartbeatCancel context.CancelFunc
 	defer func() {

--- a/src/services/worker/internal/pipeline/channel_sender_qqbot_test.go
+++ b/src/services/worker/internal/pipeline/channel_sender_qqbot_test.go
@@ -24,7 +24,7 @@ func TestQQBotChannelSenderKeepsReplyIDForAllSegments(t *testing.T) {
 				t.Fatalf("decode send body: %v", err)
 			}
 			bodies = append(bodies, body)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"id":"msg-%d"}`, len(bodies))))
+			_, _ = fmt.Fprintf(w, `{"id":"msg-%d"}`, len(bodies))
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}

--- a/src/services/worker/internal/tools/builtin/web_fetch/basic.go
+++ b/src/services/worker/internal/tools/builtin/web_fetch/basic.go
@@ -129,7 +129,7 @@ func shouldRetryBasicFetch(ctx context.Context, err error) bool {
 		return false
 	}
 	var netErr net.Error
-	if errors.As(err, &netErr) && (netErr.Timeout() || netErr.Temporary()) {
+	if errors.As(err, &netErr) && netErr.Timeout() {
 		return true
 	}
 	message := strings.ToLower(err.Error())

--- a/src/services/worker/internal/tools/builtin/web_fetch/executor.go
+++ b/src/services/worker/internal/tools/builtin/web_fetch/executor.go
@@ -292,9 +292,6 @@ func classifyFetchFailure(err error) fetchFailure {
 		if netErr.Timeout() {
 			return fetchFailure{reason: fetchFailureNetworkTimeout, retryable: true}
 		}
-		if netErr.Temporary() {
-			return fetchFailure{reason: fetchFailureNetworkError, retryable: true}
-		}
 	}
 
 	message := strings.ToLower(err.Error())


### PR DESCRIPTION
## Summary
- fix Go lint failures in shared and worker by handling closes, removing deprecated net.Error.Temporary usage, and simplifying a test write
- keep KaTeX in the synchronous markdown plugin chain so math tests and first render match runtime expectations
- stabilize web tests around app startup, locale-dependent labels, thread-list context, and replayed search steps

## Verification
- `pnpm run guard:no-org`
- `pnpm --filter @arkloop/shared test`
- `pnpm --filter web test`
- `pnpm --filter web type-check`
- `pnpm --filter web lint`
- `pnpm --filter web build`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --timeout=10m --default=none --enable=errcheck,govet,staticcheck` in `src/services/shared`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --timeout=10m --default=none --enable=errcheck,govet,staticcheck` in `src/services/worker`
- `go test ./localproviders ./qqbotclient` in `src/services/shared`
- `go test ./internal/pipeline ./internal/tools/builtin/web_fetch` in `src/services/worker`