### PR TITLE
feat: increase default llm retry attempts & jitter llm retry backoff

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -51,7 +51,7 @@
 | limit.tool_continuation_budget | int | platform | 32 | false | 长工具 continuation 总预算上限 |
 | llm.max_response_bytes | int | platform | 16384 | false | LLM Provider HTTP 响应读取上限（字节） |
 | llm.retry.base_delay_ms | int | platform | 1000 | false | LLM 重试基础延迟（毫秒） |
-| llm.retry.max_attempts | int | platform | 3 | false | LLM 重试最大次数 |
+| llm.retry.max_attempts | int | platform | 10 | false | LLM 重试最大次数 |
 | memory.distill_enabled | bool | both | true | false | 启用普通对话在 run 结束后的自动 Memory 提炼 |
 | memory.impression_score_threshold | int | both | 50 | false | impression 更新触发阈值 |
 | openviking.base_url | string | platform |  | false | OpenViking Base URL |

--- a/src/apps/developers/content/docs/en/reference/configuration.md
+++ b/src/apps/developers/content/docs/en/reference/configuration.md
@@ -32,7 +32,7 @@ title: "Configuration Reference"
 | limit.team_members | int | both | 0 | false | Maximum team member limit; 0 means unlimited |
 | llm.max_response_bytes | int | platform | 16384 | false | Maximum limit for reading LLM Provider HTTP responses (bytes) |
 | llm.retry.base_delay_ms | int | platform | 1000 | false | Base delay for LLM retries (milliseconds) |
-| llm.retry.max_attempts | int | platform | 3 | false | Maximum number of LLM retry attempts |
+| llm.retry.max_attempts | int | platform | 10 | false | Maximum number of LLM retry attempts |
 | openviking.base_url | string | platform |  | false | OpenViking Base URL |
 | openviking.cost_per_commit | number | platform | 0 | false | OpenViking CommitSession Cost (USD) |
 | openviking.root_api_key | string | platform |  | true | OpenViking Root API Key |

--- a/src/apps/developers/content/docs/zh/reference/configuration.md
+++ b/src/apps/developers/content/docs/zh/reference/configuration.md
@@ -32,7 +32,7 @@ title: "配置参考"
 | limit.team_members | int | both | 0 | false | Team 成员数量上限，0 表示不限 |
 | llm.max_response_bytes | int | platform | 16384 | false | LLM Provider HTTP 响应读取上限（字节） |
 | llm.retry.base_delay_ms | int | platform | 1000 | false | LLM 重试基础延迟（毫秒） |
-| llm.retry.max_attempts | int | platform | 3 | false | LLM 重试最大次数 |
+| llm.retry.max_attempts | int | platform | 10 | false | LLM 重试最大次数 |
 | openviking.base_url | string | platform |  | false | OpenViking Base URL |
 | openviking.cost_per_commit | number | platform | 0 | false | OpenViking CommitSession Cost (USD) |
 | openviking.root_api_key | string | platform |  | true | OpenViking Root API Key |

--- a/src/services/shared/config/track_a.go
+++ b/src/services/shared/config/track_a.go
@@ -186,7 +186,7 @@ func RegisterTrackA(r *Registry) error {
 		{
 			Key:         "llm.retry.max_attempts",
 			Type:        TypeInt,
-			Default:     "3",
+			Default:     "10",
 			Description: "LLM 重试最大次数",
 			Sensitive:   false,
 			Scope:       ScopePlatform,

--- a/src/services/worker/internal/agent/loop.go
+++ b/src/services/worker/internal/agent/loop.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"sort"
 	"strings"
 	"sync"
@@ -1791,13 +1792,30 @@ func recordRunEnd(ctx context.Context, recorder *rollout.Recorder, status string
 	appendRolloutSync(ctx, recorder, MakeRunEnd(status))
 }
 
-// retryBackoffMs 计算指数退避等待时长，最大 60s。
+const maxRetryBackoffMs = 60_000
+
+// retryBackoffMs 计算带 full jitter 的指数退避等待时长，最大 60s。
 func retryBackoffMs(baseMs, attempt int) int {
-	ms := baseMs * (1 << (attempt - 1))
-	if ms > 60_000 {
-		ms = 60_000
+	return retryBackoffMsWithRand(baseMs, attempt, func(n int) int {
+		return rand.IntN(n)
+	})
+}
+
+func retryBackoffMsWithRand(baseMs, attempt int, randIntN func(int) int) int {
+	if baseMs <= 0 {
+		baseMs = 1000
 	}
-	return ms
+	if attempt <= 0 {
+		attempt = 1
+	}
+	capMs := baseMs * (1 << (attempt - 1))
+	if capMs > maxRetryBackoffMs {
+		capMs = maxRetryBackoffMs
+	}
+	if randIntN == nil {
+		return capMs
+	}
+	return randIntN(capMs + 1)
 }
 
 func (l *Loop) runSingleTurn(

--- a/src/services/worker/internal/agent/loop_test.go
+++ b/src/services/worker/internal/agent/loop_test.go
@@ -2050,21 +2050,27 @@ func TestCompactToolResultsWithStateKeepsReplacementStableAcrossTurns(t *testing
 	}
 }
 
-func TestRetryBackoffMsCapsAt60Seconds(t *testing.T) {
-	got := []int{
-		retryBackoffMs(1000, 1),
-		retryBackoffMs(1000, 2),
-		retryBackoffMs(1000, 3),
-		retryBackoffMs(1000, 4),
-		retryBackoffMs(1000, 5),
-		retryBackoffMs(1000, 6),
-		retryBackoffMs(1000, 7),
-	}
-	want := []int{1000, 2000, 4000, 8000, 16000, 32000, 60000}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("attempt %d: got %d want %d", i+1, got[i], want[i])
+func TestRetryBackoffMsUsesFullJitterWithinCap(t *testing.T) {
+	got := retryBackoffMsWithRand(1000, 3, func(n int) int {
+		if n != 4001 {
+			t.Fatalf("rand upper bound = %d, want 4001", n)
 		}
+		return 1375
+	})
+	if got != 1375 {
+		t.Fatalf("retryBackoffMsWithRand() = %d, want 1375", got)
+	}
+}
+
+func TestRetryBackoffMsCapsBeforeApplyingJitter(t *testing.T) {
+	got := retryBackoffMsWithRand(1000, 10, func(n int) int {
+		if n != 60001 {
+			t.Fatalf("rand upper bound = %d, want 60001", n)
+		}
+		return 60000
+	})
+	if got != 60000 {
+		t.Fatalf("retryBackoffMsWithRand() = %d, want 60000", got)
 	}
 }
 

--- a/src/services/worker/internal/app/composition.go
+++ b/src/services/worker/internal/app/composition.go
@@ -335,7 +335,7 @@ func ComposeNativeEngine(ctx context.Context, pool *pgxpool.Pool, directPool *pg
 		}
 	}
 
-	llmRetryMaxAttempts := 3
+	llmRetryMaxAttempts := 10
 	llmRetryBaseDelayMs := 1000
 	if configResolver != nil {
 		m, err := configResolver.ResolvePrefix(ctx, "llm.retry.", sharedconfig.Scope{})

--- a/src/services/worker/internal/app/composition_desktop_compact.go
+++ b/src/services/worker/internal/app/composition_desktop_compact.go
@@ -55,15 +55,15 @@ func resolveDesktopContextCompact(ctx context.Context, db data.DesktopDB) (pipel
 func resolveDesktopLLMRetry(ctx context.Context, db data.DesktopDB) (int, int) {
 	registry := sharedconfig.DefaultRegistry()
 	if db == nil {
-		return desktopResolvePositiveInt(ctx, nil, registry, "llm.retry.max_attempts", sharedconfig.Scope{}, 3),
+		return desktopResolvePositiveInt(ctx, nil, registry, "llm.retry.max_attempts", sharedconfig.Scope{}, 10),
 			desktopResolvePositiveInt(ctx, nil, registry, "llm.retry.base_delay_ms", sharedconfig.Scope{}, 1000)
 	}
 	resolver, err := sharedconfig.NewResolver(registry, sharedconfig.NewPGXStoreQuerier(db), nil, 0)
 	if err != nil {
-		return 3, 1000
+		return 10, 1000
 	}
 	scope := sharedconfig.Scope{}
-	return desktopResolvePositiveInt(ctx, resolver, registry, "llm.retry.max_attempts", scope, 3),
+	return desktopResolvePositiveInt(ctx, resolver, registry, "llm.retry.max_attempts", scope, 10),
 		desktopResolvePositiveInt(ctx, resolver, registry, "llm.retry.base_delay_ms", scope, 1000)
 }
 

--- a/src/services/worker/internal/app/composition_desktop_test.go
+++ b/src/services/worker/internal/app/composition_desktop_test.go
@@ -288,8 +288,8 @@ func TestResolveDesktopLLMRetryReadsPlatformSettings(t *testing.T) {
 	mustExecDesktopSQL(t, db, `CREATE TABLE IF NOT EXISTS platform_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`)
 
 	maxAttempts, baseDelayMs := resolveDesktopLLMRetry(ctx, db)
-	if maxAttempts != 3 || baseDelayMs != 1000 {
-		t.Fatalf("default retry config = (%d, %d), want (3, 1000)", maxAttempts, baseDelayMs)
+	if maxAttempts != 10 || baseDelayMs != 1000 {
+		t.Fatalf("default retry config = (%d, %d), want (10, 1000)", maxAttempts, baseDelayMs)
 	}
 
 	for key, value := range map[string]string{


### PR DESCRIPTION
增强了模型连接失败的重试机制，增加了默认重试次数到 10，并支持抖动指数退避