### PR TITLE
fix(web): refine desktop background surfaces

### DIFF
--- a/src/apps/web/src/__tests__/appUI.test.tsx
+++ b/src/apps/web/src/__tests__/appUI.test.tsx
@@ -236,7 +236,7 @@ describe('DesktopTitleBar update entry', () => {
     await renderTitleBar(appUpdateState('available'), true)
 
     const titleBar = container.firstElementChild as HTMLElement | null
-    expect(titleBar?.style.paddingLeft).toBe('8px')
+    expect(titleBar?.style.paddingLeft).toBe('12px')
     expect(container.querySelector('button[title="Minimize"]')).toBeNull()
   })
 
@@ -246,7 +246,7 @@ describe('DesktopTitleBar update entry', () => {
     await renderTitleBar(appUpdateState('available'), true)
 
     const titleBar = container.firstElementChild as HTMLElement | null
-    expect(titleBar?.style.paddingLeft).toBe('8px')
+    expect(titleBar?.style.paddingLeft).toBe('12px')
     expect(container.querySelector('button[title="Minimize"]')).toBeNull()
   })
 

--- a/src/apps/web/src/components/ChatInput.tsx
+++ b/src/apps/web/src/components/ChatInput.tsx
@@ -540,16 +540,13 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     return () => cancelAnimationFrame(id)
   }, [persistSelectedPersona, searchMode, selectedPersonaKey])
 
-  // sync persona when appMode changes
-  useEffect(() => {
-    const id = requestAnimationFrame(() => {
-      if (appMode === 'work' && selectedPersonaKey !== WORK_PERSONA_KEY) {
-        persistSelectedPersona(WORK_PERSONA_KEY)
-      } else if (appMode !== 'work' && selectedPersonaKey === WORK_PERSONA_KEY) {
-        persistSelectedPersona(DEFAULT_PERSONA_KEY)
-      }
-    })
-    return () => cancelAnimationFrame(id)
+  // 模式切换时在首帧前同步 persona
+  useLayoutEffect(() => {
+    if (appMode === 'work' && selectedPersonaKey !== WORK_PERSONA_KEY) {
+      persistSelectedPersona(WORK_PERSONA_KEY)
+    } else if (appMode !== 'work' && selectedPersonaKey === WORK_PERSONA_KEY) {
+      persistSelectedPersona(DEFAULT_PERSONA_KEY)
+    }
   }, [persistSelectedPersona, appMode, selectedPersonaKey])
 
   const typewriterTarget = placeholder

--- a/src/apps/web/src/components/ChatView.tsx
+++ b/src/apps/web/src/components/ChatView.tsx
@@ -2490,7 +2490,6 @@ export const ChatView = memo(function ChatView() {
 
   const chatInputEl = useMemo(() => (
     <ChatInput
-      key={`${threadId ?? '__no_thread__'}:${effectiveAppMode}:${isSearchThread ? 'search' : 'default'}`}
       ref={chatInputRef}
       onSubmit={handleSend}
       onCancel={handleCancel}
@@ -2629,13 +2628,13 @@ export const ChatView = memo(function ChatView() {
   }
 
   return (
-    <div className="theme-surface-page relative flex min-w-0 flex-1 flex-col overflow-hidden bg-[var(--c-bg-page)]">
+    <div className="theme-surface-page theme-chat-surface relative flex min-w-0 flex-1 flex-col overflow-hidden bg-[var(--c-bg-page)]">
       <ChatTitleMenu />
 
       {/* 主体区域：消息 + 输入 + 可选的 sources 侧边面板 */}
       <div className="relative flex flex-1 min-h-0">
         <div className="relative flex flex-1 min-w-0 flex-col">
-          <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-10" style={{ background: 'linear-gradient(to bottom, var(--c-bg-page-gradient-stop, var(--c-bg-page)), transparent)' }} />
+          <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-10" style={{ background: 'linear-gradient(to bottom, var(--c-chat-bg-gradient-stop, var(--c-bg-page-gradient-stop, var(--c-bg-page))), transparent)' }} />
           {/* 消息列表 */}
           <div
             ref={scrollContainerRef}
@@ -2757,7 +2756,7 @@ export const ChatView = memo(function ChatView() {
           left: 0,
           right: 0,
           zIndex: 10,
-          background: 'linear-gradient(to bottom, transparent 0%, var(--c-bg-page-gradient-stop, var(--c-bg-page)) 24px)',
+          background: 'linear-gradient(to bottom, transparent 0%, var(--c-chat-bg-gradient-stop, var(--c-bg-page-gradient-stop, var(--c-bg-page))) 24px)',
         } as React.CSSProperties}
         className="flex w-full flex-col items-center gap-2"
       >

--- a/src/apps/web/src/components/DesktopSettings.tsx
+++ b/src/apps/web/src/components/DesktopSettings.tsx
@@ -498,7 +498,7 @@ export function DesktopSettings({
   return (
     <>
       <motion.div
-        className="flex h-full min-h-0 min-w-0 flex-1 overflow-hidden"
+        className="theme-surface-page flex h-full min-h-0 min-w-0 flex-1 overflow-hidden bg-[var(--c-bg-page)]"
         style={settingsMotionStyle}
         initial={{ opacity: 0, x: 10 }}
         animate={{ opacity: 1, x: 0 }}
@@ -507,7 +507,7 @@ export function DesktopSettings({
         onAnimationComplete={handleMotionComplete}
       >
         <div
-          className="flex w-[280px] shrink-0 flex-col overflow-y-auto py-4"
+          className="theme-surface-sidebar flex w-[280px] shrink-0 flex-col overflow-y-auto bg-[var(--c-bg-sidebar)] py-4"
           style={{
             borderRight: "0.5px solid var(--c-border-subtle)",
             transform: "translateZ(0)",
@@ -533,7 +533,7 @@ export function DesktopSettings({
           <div
             className="pointer-events-none absolute left-0 right-0 top-0 z-10 h-8 transition-opacity duration-200"
             style={{
-              background: 'linear-gradient(to bottom, var(--c-bg-page) 0%, transparent 100%)',
+              background: 'linear-gradient(to bottom, var(--c-bg-page-gradient-stop, var(--c-bg-page)) 0%, transparent 100%)',
               opacity: scrolled ? 1 : 0,
             }}
           />

--- a/src/apps/web/src/components/DesktopTitleBar.tsx
+++ b/src/apps/web/src/components/DesktopTitleBar.tsx
@@ -26,7 +26,7 @@ import { secondaryButtonSmCls, secondaryButtonBorderStyle } from './buttonStyles
 export const DESKTOP_TITLEBAR_HEIGHT = 44
 const WINDOWS_TITLEBAR_HEIGHT = 44
 const MAC_TITLEBAR_LEFT_PADDING = 76
-const DESKTOP_ICON_RAIL_LEFT_PADDING = 8
+const DESKTOP_ICON_RAIL_LEFT_PADDING = 12
 
 type Props = {
   sidebarCollapsed: boolean

--- a/src/apps/web/src/components/SettingsModal.tsx
+++ b/src/apps/web/src/components/SettingsModal.tsx
@@ -89,7 +89,7 @@ export function SettingsModal({ me, accessToken, initialTab = 'account', onClose
       onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
       <div
-        className="modal-enter flex overflow-hidden rounded-2xl shadow-2xl bg-[var(--c-bg-page)]"
+        className="theme-surface-page modal-enter flex overflow-hidden rounded-2xl bg-[var(--c-bg-page)] shadow-2xl"
         style={{
           width: '832px',
           height: '624px',
@@ -98,7 +98,7 @@ export function SettingsModal({ me, accessToken, initialTab = 'account', onClose
       >
         {/* nav */}
         <div
-          className="flex w-[200px] shrink-0 flex-col py-4 bg-[var(--c-bg-sidebar)]"
+          className="theme-surface-sidebar flex w-[200px] shrink-0 flex-col bg-[var(--c-bg-sidebar)] py-4"
           style={{ borderRight: '0.5px solid rgba(0,0,0,0.14)' }}
         >
           <div className="mb-2 px-4 py-1">

--- a/src/apps/web/src/components/WelcomePage.tsx
+++ b/src/apps/web/src/components/WelcomePage.tsx
@@ -418,7 +418,7 @@ export function WelcomePage() {
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="theme-surface-page theme-chat-surface flex h-full flex-col bg-[var(--c-bg-page)]">
       {/* 顶部 header */}
       <div className="relative z-10 flex min-h-[51px] items-center justify-end gap-2 px-[15px] py-[15px]">
         {!isDesktop() && (
@@ -497,7 +497,6 @@ export function WelcomePage() {
 
         <div className="w-full max-w-[675px]">
           <ChatInput
-            key={`welcome:${appMode}:${isSearchMode ? 'search' : 'default'}`}
             ref={chatInputRef}
             onSubmit={handleSubmit}
             placeholder={isSearchMode ? '今天有什么想搜索的吗？' : t.chatPlaceholder}

--- a/src/apps/web/src/index.css
+++ b/src/apps/web/src/index.css
@@ -52,6 +52,7 @@ button:not(:disabled) {
   --c-background-image-scrim-alpha: calc(0.18 + ((1 - var(--c-background-image-opacity)) * 0.34));
   --c-background-image-vignette-alpha: 0.22;
   --c-bg-page-gradient-stop: var(--c-bg-page);
+  --c-chat-bg-gradient-stop: var(--c-bg-page-gradient-stop);
   --c-bg-sidebar: #242422;
   --c-bg-deep: #141413;
   --c-bg-sub: #1e1e1c;
@@ -1557,6 +1558,14 @@ button:not(:disabled) {
 
   :root[data-background-image="custom"] .theme-surface-page .theme-surface-page {
     background-color: transparent;
+  }
+
+  :root[data-background-image="custom"] {
+    --c-chat-bg-gradient-stop: color-mix(in srgb, var(--c-bg-page) 42%, transparent);
+  }
+
+  :root[data-background-image="custom"] .theme-chat-surface {
+    background-color: color-mix(in srgb, var(--c-bg-page) 42%, transparent);
   }
 }
 


### PR DESCRIPTION
## Summary
- keep desktop custom-background surfaces translucent across chat, welcome, settings, and modal layouts
- preserve the chat background fade with a dedicated chat gradient stop
- avoid remounting chat input when switching mode and sync persona before paint
- update desktop title bar spacing expectations

## Verification
- pnpm --dir src/apps/web test -- appUI.test.tsx
- pnpm --dir src/apps/web type-check
- pnpm --dir src/apps/web lint
- pnpm --dir src/apps/web build
- git diff --check