### PR TITLE
fix(desktop): restore user config runtime

### DIFF
--- a/src/apps/desktop/src/main/ipc.ts
+++ b/src/apps/desktop/src/main/ipc.ts
@@ -41,8 +41,18 @@ type DesktopExportSection =
   | 'themes'
 
 type DesktopThemeExportPayload = {
+  themePreset?: string | null
   customThemeId: string | null
   customThemes: Record<string, unknown>
+  backgroundImage?: {
+    dataUrl: string
+    name: string
+    mimeType: string
+    size: number
+    updatedAt: number
+  } | null
+  backgroundImageOpacity?: number | null
+  sidebarGrouping?: 'normal' | 'gtd' | null
 }
 
 type DesktopExportOptions = {
@@ -1111,7 +1121,14 @@ function exportDesktopBundle(destRoot: string, pathModule: typeof import('path')
   if (sections.includes('themes')) {
     fs.writeFileSync(
       pathModule.join(outDir, 'themes.json'),
-      JSON.stringify(options?.themes ?? { customThemeId: null, customThemes: {} }, null, 2),
+      JSON.stringify(options?.themes ?? {
+        themePreset: null,
+        customThemeId: null,
+        customThemes: {},
+        backgroundImage: null,
+        backgroundImageOpacity: null,
+        sidebarGrouping: null,
+      }, null, 2),
       'utf-8',
     )
     exportedFiles.push('themes.json')

--- a/src/apps/desktop/src/preload/index.ts
+++ b/src/apps/desktop/src/preload/index.ts
@@ -228,8 +228,18 @@ export type DesktopExportSection =
   | 'themes'
 
 export type DesktopThemeExportPayload = {
+  themePreset?: string | null
   customThemeId: string | null
   customThemes: Record<string, unknown>
+  backgroundImage?: {
+    dataUrl: string
+    name: string
+    mimeType: string
+    size: number
+    updatedAt: number
+  } | null
+  backgroundImageOpacity?: number | null
+  sidebarGrouping?: 'normal' | 'gtd' | null
 }
 
 export type DesktopExportOptions = {

--- a/src/apps/shared/src/assistantTurn.ts
+++ b/src/apps/shared/src/assistantTurn.ts
@@ -63,6 +63,13 @@ export function splitWorkGroup(
   const finalSegment = segments[lastTextIndex]!
   const finalText = finalSegment.type === 'text' ? finalSegment.content : null
 
+  if (lastTextIndex < segments.length - 1) {
+    return {
+      workGroup: segments.length >= 2 ? { durationMs, segments } : null,
+      finalText: null,
+    }
+  }
+
   // Need at least 2 segments before final to justify a work group.
   // A single pre-final segment (text or cop) stays inline.
   if (lastTextIndex < 2) {

--- a/src/apps/shared/src/desktop.ts
+++ b/src/apps/shared/src/desktop.ts
@@ -348,8 +348,18 @@ export type DesktopExportSection =
   | 'themes'
 
 export type DesktopThemeExportPayload = {
+  themePreset?: string | null
   customThemeId: string | null
   customThemes: Record<string, unknown>
+  backgroundImage?: {
+    dataUrl: string
+    name: string
+    mimeType: string
+    size: number
+    updatedAt: number
+  } | null
+  backgroundImageOpacity?: number | null
+  sidebarGrouping?: 'normal' | 'gtd' | null
 }
 
 export type DesktopExportOptions = {

--- a/src/apps/web/src/__tests__/advancedSettings.test.tsx
+++ b/src/apps/web/src/__tests__/advancedSettings.test.tsx
@@ -102,6 +102,7 @@ describe('AdvancedSettings', () => {
       return {
         ...actual,
         readLocaleFromStorage: vi.fn(() => 'zh'),
+        readGtdEnabled: vi.fn(() => false),
         writeLocaleToStorage: vi.fn(),
       }
     })
@@ -140,10 +141,16 @@ describe('AdvancedSettings', () => {
     }))
     vi.doMock('../contexts/AppearanceContext', () => ({
       useAppearance: () => ({
+        themePreset: 'default',
+        setThemePreset: vi.fn(),
         customThemeId: null,
         customThemes: {},
         saveCustomTheme: vi.fn(),
         setActiveCustomTheme: vi.fn(),
+        backgroundImage: null,
+        setBackgroundImage: vi.fn(() => true),
+        backgroundImageOpacity: 40,
+        setBackgroundImageOpacity: vi.fn(),
       }),
     }))
     vi.doMock('@arkloop/shared', async () => {
@@ -228,6 +235,7 @@ describe('AdvancedSettings', () => {
       return {
         ...actual,
         readLocaleFromStorage: vi.fn(() => 'zh'),
+        readGtdEnabled: vi.fn(() => true),
         writeLocaleToStorage: vi.fn(),
       }
     })
@@ -255,10 +263,22 @@ describe('AdvancedSettings', () => {
     }))
     vi.doMock('../contexts/AppearanceContext', () => ({
       useAppearance: () => ({
+        themePreset: 'background-image',
+        setThemePreset: vi.fn(),
         customThemeId: null,
         customThemes: {},
         saveCustomTheme: vi.fn(),
         setActiveCustomTheme: vi.fn(),
+        backgroundImage: {
+          dataUrl: 'data:image/png;base64,Ymc=',
+          name: 'bg.png',
+          mimeType: 'image/png',
+          size: 2,
+          updatedAt: 1234,
+        },
+        setBackgroundImage: vi.fn(() => true),
+        backgroundImageOpacity: 55,
+        setBackgroundImageOpacity: vi.fn(),
       }),
     }))
     vi.doMock('@arkloop/shared', async () => {
@@ -311,5 +331,29 @@ describe('AdvancedSettings', () => {
       '自定义主题',
     ])
     expect(exportDataBundle).not.toHaveBeenCalled()
+
+    const exportLabel = exportButton!.textContent?.trim()
+    const confirmExportButton = Array.from(document.body.querySelectorAll('button'))
+      .filter((button) => button.textContent?.trim() === exportLabel)
+      .at(-1)
+    expect(confirmExportButton).toBeTruthy()
+
+    await act(async () => {
+      confirmExportButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await flushEffects()
+
+    expect(exportDataBundle).toHaveBeenCalledWith(expect.objectContaining({
+      sections: expect.arrayContaining(['themes']),
+      themes: expect.objectContaining({
+        themePreset: 'background-image',
+        backgroundImage: expect.objectContaining({
+          dataUrl: 'data:image/png;base64,Ymc=',
+          name: 'bg.png',
+        }),
+        backgroundImageOpacity: 55,
+        sidebarGrouping: 'gtd',
+      }),
+    }))
   })
 })

--- a/src/apps/web/src/__tests__/appUI.test.tsx
+++ b/src/apps/web/src/__tests__/appUI.test.tsx
@@ -236,7 +236,7 @@ describe('DesktopTitleBar update entry', () => {
     await renderTitleBar(appUpdateState('available'), true)
 
     const titleBar = container.firstElementChild as HTMLElement | null
-    expect(titleBar?.style.paddingLeft).toBe('8px')
+    expect(titleBar?.style.paddingLeft).toBe('12px')
     expect(container.querySelector('button[title="Minimize"]')).toBeNull()
   })
 
@@ -246,7 +246,7 @@ describe('DesktopTitleBar update entry', () => {
     await renderTitleBar(appUpdateState('available'), true)
 
     const titleBar = container.firstElementChild as HTMLElement | null
-    expect(titleBar?.style.paddingLeft).toBe('8px')
+    expect(titleBar?.style.paddingLeft).toBe('12px')
     expect(container.querySelector('button[title="Minimize"]')).toBeNull()
   })
 

--- a/src/apps/web/src/__tests__/appearanceStorage.test.ts
+++ b/src/apps/web/src/__tests__/appearanceStorage.test.ts
@@ -4,9 +4,12 @@ import type { ThemeBackgroundImage } from '../themes/types'
 import {
   readBackgroundImageFromStorage,
   readBackgroundImageOpacityFromStorage,
+  readGtdEnabled,
   readThemePresetFromStorage,
+  subscribeGtdEnabled,
   writeBackgroundImageToStorage,
   writeBackgroundImageOpacityToStorage,
+  writeGtdEnabled,
   writeThemePresetToStorage,
 } from '../storage'
 
@@ -104,5 +107,20 @@ describe('appearance storage', () => {
   it('stores the custom background color scheme', () => {
     writeThemePresetToStorage('background-image')
     expect(readThemePresetFromStorage()).toBe('background-image')
+  })
+
+  it('同步 GTD 分组状态变更', () => {
+    const observed: boolean[] = []
+    const unsubscribe = subscribeGtdEnabled((enabled) => observed.push(enabled))
+
+    writeGtdEnabled(true)
+    expect(readGtdEnabled()).toBe(true)
+    expect(observed).toEqual([true])
+
+    writeGtdEnabled(false)
+    expect(readGtdEnabled()).toBe(false)
+    expect(observed).toEqual([true, false])
+
+    unsubscribe()
   })
 })

--- a/src/apps/web/src/__tests__/chatInputPersonaSelector.test.tsx
+++ b/src/apps/web/src/__tests__/chatInputPersonaSelector.test.tsx
@@ -128,7 +128,7 @@ describe('ChatInput persona selector', () => {
     }
   })
 
-  it('按动态列表循环切换并可从下拉选择人格', async () => {
+  it('不再从加号菜单加载动态人格，提交沿用已选人格', async () => {
     const onSubmit = vi.fn<(event: FormEvent<HTMLFormElement>, personaKey: string) => void>((event) => event.preventDefault())
     const container = document.createElement('div')
     document.body.appendChild(container)
@@ -148,45 +148,9 @@ describe('ChatInput persona selector', () => {
       await flushMicrotasks()
     })
 
-    expect(mockedListSelectablePersonas).toHaveBeenCalledWith('token')
-
-    const selectorButton = findButtonByText(container, 'Normal')
-    expect(selectorButton).not.toBeNull()
-    if (!selectorButton) return
-
-    await act(async () => {
-      selectorButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
-
-    const searchMenuButton = Array.from(container.querySelectorAll('button')).find(
-      (button) => button !== selectorButton && button.textContent?.trim() === 'Search',
-    ) as HTMLButtonElement | null
-    expect(searchMenuButton).not.toBeNull()
-    if (!searchMenuButton) return
-
-    await act(async () => {
-      searchMenuButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
-
-    expect(findButtonByText(container, 'Search')).not.toBeNull()
-
-    const searchSelectorButton = findButtonByText(container, 'Search')
-    expect(searchSelectorButton).not.toBeNull()
-    if (!searchSelectorButton) return
-
-    await act(async () => {
-      searchSelectorButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
-
-    const menuNormalButton = Array.from(container.querySelectorAll('button')).find(
-      (button) => button !== searchSelectorButton && button.textContent?.trim() === 'Normal',
-    ) as HTMLButtonElement | null
-    expect(menuNormalButton).not.toBeNull()
-    if (!menuNormalButton) return
-
-    await act(async () => {
-      menuNormalButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+    expect(mockedListSelectablePersonas).not.toHaveBeenCalled()
+    expect(findButtonByText(container, 'Normal')).toBeFalsy()
+    expect(findButtonByText(container, 'Search')).toBeFalsy()
 
     const form = container.querySelector('form')
     expect(form).not.toBeNull()

--- a/src/apps/web/src/__tests__/chatPageLoading.test.tsx
+++ b/src/apps/web/src/__tests__/chatPageLoading.test.tsx
@@ -1001,7 +1001,10 @@ describe('ChatPage loading state', () => {
     mockedReadMessageTerminalStatus.mockReturnValue(null)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    sseMock.clearEventListeners()
+    sseMock.events = []
+    await flushMicrotasks()
     HTMLElement.prototype.scrollIntoView = originalScrollIntoView
     if (originalActEnvironment === undefined) {
       delete actEnvironment.IS_REACT_ACT_ENVIRONMENT
@@ -3740,6 +3743,7 @@ describe('ChatPage loading state', () => {
       expect(container.textContent ?? '').toContain('streaming')
       expect(sseMock.reset).toHaveBeenCalled()
       expect(sseMock.connect).toHaveBeenCalled()
+      expect(sseMock.subscribeEvents).toHaveBeenCalled()
     })
 
     await act(async () => {
@@ -3792,6 +3796,7 @@ describe('ChatPage loading state', () => {
       root.render(renderTree())
       await flushMicrotasks()
       await flushMicrotasks()
+      await flushAnimationFrames(2)
     })
 
     await waitForAssertion(() => {

--- a/src/apps/web/src/__tests__/desktopChannelsSettings.test.tsx
+++ b/src/apps/web/src/__tests__/desktopChannelsSettings.test.tsx
@@ -118,6 +118,9 @@ async function loadChannelsSubject() {
       updateChannel: vi.fn(),
       verifyChannel: vi.fn(),
       createChannelBindCode: vi.fn(),
+      listChannelBindings: vi.fn().mockResolvedValue([]),
+      updateChannelBinding: vi.fn(),
+      deleteChannelBinding: vi.fn(),
       unbindChannelIdentity: vi.fn(),
       isApiError: vi.fn(() => false),
     }
@@ -509,6 +512,93 @@ describe('DesktopChannelsSettings', () => {
     expect(document.body.textContent).toContain('Arkloop DM')
     expect(document.body.textContent).toContain('@arkloop_bot')
     expect(document.body.textContent).toContain('app-123')
+  })
+
+  it('可以保存 QQ OneBot 的 Bot 名称配置', async () => {
+    const { api, DesktopChannelsSettings, LocaleProvider } = await loadChannelsSubject()
+    const qqChannel = {
+      id: 'qq-1',
+      account_id: 'acc-1',
+      channel_type: 'qq',
+      persona_id: 'persona-1',
+      webhook_url: null,
+      is_active: true,
+      config_json: {
+        onebot_ws_url: 'ws://127.0.0.1:6098',
+        onebot_http_url: 'http://127.0.0.1:3000',
+        onebot_token: 'secret',
+        bot_name: 'Old Bot',
+        allowed_user_ids: ['10001'],
+        allowed_group_ids: ['20001'],
+      },
+      has_credentials: true,
+      created_at: '2026-03-26T00:00:00Z',
+      updated_at: '2026-03-26T00:00:00Z',
+    }
+    vi.mocked(api.listChannels).mockResolvedValue([qqChannel])
+    vi.mocked(api.listMyChannelIdentities).mockResolvedValue([])
+    vi.mocked(api.listChannelPersonas).mockResolvedValue([
+      {
+        id: 'persona-1',
+        persona_key: 'normal',
+        version: '1',
+        display_name: 'Normal',
+        source: 'project',
+      } as never,
+    ])
+    vi.mocked(api.listLlmProviders).mockResolvedValue([])
+    vi.mocked(api.listChannelBindings).mockResolvedValue([])
+    vi.mocked(api.updateChannel).mockResolvedValue({
+      ...qqChannel,
+      config_json: {
+        ...qqChannel.config_json,
+        bot_name: 'New Bot',
+      },
+    })
+
+    await act(async () => {
+      root!.render(
+        <LocaleProvider>
+          <DesktopChannelsSettings accessToken="token" />
+        </LocaleProvider>,
+      )
+    })
+    await flushEffects()
+
+    const qqOneBotTab = Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes('OneBot'))
+    expect(qqOneBotTab).toBeTruthy()
+
+    await act(async () => {
+      qqOneBotTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await flushEffects()
+
+    const botNameInput = Array.from(document.body.querySelectorAll('input')).find((input) => input.value === 'Old Bot') as HTMLInputElement
+    expect(botNameInput).toBeTruthy()
+
+    await act(async () => {
+      setInputValue(botNameInput, 'New Bot')
+    })
+    await flushEffects()
+
+    const saveButton = Array.from(document.body.querySelectorAll('button')).find((button) => button.textContent?.trim() === '保存')
+    await act(async () => {
+      saveButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await flushEffects()
+
+    expect(api.updateChannel).toHaveBeenCalledWith('token', 'qq-1', {
+      persona_id: 'persona-1',
+      is_active: true,
+      config_json: {
+        onebot_ws_url: 'ws://127.0.0.1:6098',
+        onebot_http_url: 'http://127.0.0.1:3000',
+        onebot_token: 'secret',
+        bot_name: 'New Bot',
+        allowed_user_ids: ['10001'],
+        allowed_group_ids: ['20001'],
+      },
+    })
   })
 
   it('可以创建飞书官方渠道并提交官方接入配置', async () => {

--- a/src/apps/web/src/__tests__/documentPanelPreview.test.tsx
+++ b/src/apps/web/src/__tests__/documentPanelPreview.test.tsx
@@ -6,23 +6,29 @@ import { ResourcePreviewPanel } from '../components/resource-preview/ResourcePre
 import { LocaleProvider } from '../contexts/LocaleContext'
 import type { ArtifactRef } from '../storage'
 
-type URLWithObjectURL = typeof URL & {
-  createObjectURL?: (object: Blob) => string
-  revokeObjectURL?: (url: string) => void
-}
+vi.mock('../components/ArtifactIframe', async () => {
+  const { createElement } = await import('react')
+  return {
+    ArtifactIframe: ({ frameTitle }: { frameTitle?: string }) => createElement('iframe', {
+      'data-preview-renderer': 'artifact-html-preview',
+      title: frameTitle ?? 'artifact',
+    }),
+  }
+})
 
 type GlobalWithActEnvironment = typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean
 }
-
-const originalRAF = globalThis.requestAnimationFrame
-const originalCAF = globalThis.cancelAnimationFrame
 
 function flushMicrotasks(): Promise<void> {
   return Promise.resolve()
     .then(() => Promise.resolve())
     .then(() => Promise.resolve())
     .then(() => Promise.resolve())
+}
+
+function fetchInputUrl(input: RequestInfo | URL): string {
+  return typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
 }
 
 async function waitForPreviewWork(predicate: () => boolean): Promise<void> {
@@ -38,32 +44,17 @@ async function waitForPreviewWork(predicate: () => boolean): Promise<void> {
 }
 
 describe('ResourcePreviewPanel artifact preview', () => {
-  const urlWithObjectURL = URL as URLWithObjectURL
   const actEnvironmentGlobal = globalThis as GlobalWithActEnvironment
-  const originalCreateObjectURL = urlWithObjectURL.createObjectURL
-  const originalRevokeObjectURL = urlWithObjectURL.revokeObjectURL
   const originalFetch = globalThis.fetch
   const originalActEnvironment = actEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT
 
   beforeEach(() => {
     actEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true
-    globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => {
-      cb(performance.now())
-      return 0
-    }
-    globalThis.cancelAnimationFrame = () => {}
-    urlWithObjectURL.createObjectURL = vi.fn(() => 'blob:artifact-preview')
-    urlWithObjectURL.revokeObjectURL = vi.fn()
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      const url = fetchInputUrl(input)
       if (url.endsWith('/doc.md')) {
         return new Response('[预览](artifact:preview.html)', {
           headers: { 'Content-Type': 'text/markdown' },
-        })
-      }
-      if (url.endsWith('/preview.html')) {
-        return new Response('<html><body>ok</body></html>', {
-          headers: { 'Content-Type': 'text/html' },
         })
       }
       return new Response('not-found', { status: 404 })
@@ -71,24 +62,12 @@ describe('ResourcePreviewPanel artifact preview', () => {
   })
 
   afterEach(() => {
-    if (originalCreateObjectURL) {
-      urlWithObjectURL.createObjectURL = originalCreateObjectURL
-    } else {
-      Reflect.deleteProperty(urlWithObjectURL, 'createObjectURL')
-    }
-    if (originalRevokeObjectURL) {
-      urlWithObjectURL.revokeObjectURL = originalRevokeObjectURL
-    } else {
-      Reflect.deleteProperty(urlWithObjectURL, 'revokeObjectURL')
-    }
     globalThis.fetch = originalFetch
     if (originalActEnvironment === undefined) {
       delete actEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT
     } else {
       actEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = originalActEnvironment
     }
-    globalThis.requestAnimationFrame = originalRAF
-    globalThis.cancelAnimationFrame = originalCAF
     vi.restoreAllMocks()
   })
 
@@ -130,12 +109,13 @@ describe('ResourcePreviewPanel artifact preview', () => {
     })
 
     await waitForPreviewWork(() => (
-      vi.mocked(globalThis.fetch).mock.calls.length >= 2 &&
-      container.querySelector('iframe') !== null
+      container.querySelector('iframe[data-preview-renderer="artifact-html-preview"]') !== null
     ))
 
-    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
-    expect(container.querySelector('iframe')).not.toBeNull()
+    const fetchUrls = vi.mocked(globalThis.fetch).mock.calls.map(([input]) => fetchInputUrl(input))
+    expect(fetchUrls).toHaveLength(1)
+    expect(fetchUrls[0]).toMatch(/\/doc\.md$/)
+    expect(container.querySelector('iframe[data-preview-renderer="artifact-html-preview"]')?.getAttribute('title')).toBe('preview.html')
 
     act(() => {
       root.unmount()

--- a/src/apps/web/src/__tests__/documentPanelPreview.test.tsx
+++ b/src/apps/web/src/__tests__/documentPanelPreview.test.tsx
@@ -1,82 +1,35 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { act } from 'react'
-import { createRoot } from 'react-dom/client'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
 
-import { ResourcePreviewPanel } from '../components/resource-preview/ResourcePreviewPanel'
-import { LocaleProvider } from '../contexts/LocaleContext'
+import { PreviewResourceView } from '../components/resource-preview/PreviewResourceView'
+import type { PreviewResource } from '../components/resource-preview/types'
 import type { ArtifactRef } from '../storage'
 
-vi.mock('../components/ArtifactIframe', async () => {
+vi.mock('../components/ArtifactHtmlPreview', async () => {
   const { createElement } = await import('react')
   return {
-    ArtifactIframe: ({ frameTitle }: { frameTitle?: string }) => createElement('iframe', {
-      'data-preview-renderer': 'artifact-html-preview',
-      title: frameTitle ?? 'artifact',
+    ArtifactHtmlPreview: ({ artifact }: { artifact: ArtifactRef }) => createElement('div', {
+      'data-artifact-html-preview': artifact.key,
+      'data-title': artifact.title ?? artifact.filename,
     }),
   }
 })
 
-type GlobalWithActEnvironment = typeof globalThis & {
-  IS_REACT_ACT_ENVIRONMENT?: boolean
-}
-
-function flushMicrotasks(): Promise<void> {
-  return Promise.resolve()
-    .then(() => Promise.resolve())
-    .then(() => Promise.resolve())
-    .then(() => Promise.resolve())
-}
-
-function fetchInputUrl(input: RequestInfo | URL): string {
-  return typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
-}
-
-async function waitForPreviewWork(predicate: () => boolean): Promise<void> {
-  for (let i = 0; i < 40; i++) {
-    if (predicate()) return
-    await act(async () => {
-      await flushMicrotasks()
-      await new Promise((resolve) => setTimeout(resolve, 0))
-    })
-  }
-  if (predicate()) return
-  throw new Error('preview did not settle')
-}
-
 describe('ResourcePreviewPanel artifact preview', () => {
-  const actEnvironmentGlobal = globalThis as GlobalWithActEnvironment
-  const originalFetch = globalThis.fetch
-  const originalActEnvironment = actEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT
-
-  beforeEach(() => {
-    actEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true
-    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
-      const url = fetchInputUrl(input)
-      if (url.endsWith('/doc.md')) {
-        return new Response('[预览](artifact:preview.html)', {
-          headers: { 'Content-Type': 'text/markdown' },
-        })
-      }
-      return new Response('not-found', { status: 404 })
-    })
-  })
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch
-    if (originalActEnvironment === undefined) {
-      delete actEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT
-    } else {
-      actEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = originalActEnvironment
-    }
-    vi.restoreAllMocks()
-  })
-
-  it('Markdown 文档中的 html artifact 应继续内联渲染', async () => {
-    const markdownArtifact: ArtifactRef = {
-      key: 'doc.md',
+  it('Markdown 文档中的 html artifact 应继续内联渲染', () => {
+    const markdownResource: PreviewResource = {
+      source: 'artifact',
+      ref: {
+        kind: 'artifact',
+        key: 'doc.md',
+        filename: 'doc.md',
+        mimeType: 'text/markdown',
+        size: 10,
+      },
       filename: 'doc.md',
+      mimeType: 'text/markdown',
       size: 10,
-      mime_type: 'text/markdown',
+      text: '[预览](artifact:preview.html)',
     }
     const htmlArtifact: ArtifactRef = {
       key: 'preview.html',
@@ -85,41 +38,15 @@ describe('ResourcePreviewPanel artifact preview', () => {
       mime_type: 'text/html',
     }
 
-    const container = document.createElement('div')
-    document.body.appendChild(container)
-    const root = createRoot(container)
+    const html = renderToStaticMarkup(
+      <PreviewResourceView
+        resource={markdownResource}
+        artifacts={[htmlArtifact]}
+        accessToken="token"
+      />,
+    )
 
-    await act(async () => {
-      root.render(
-        <LocaleProvider>
-          <ResourcePreviewPanel
-            resource={{
-              kind: 'artifact',
-              key: markdownArtifact.key,
-              filename: markdownArtifact.filename,
-              mimeType: markdownArtifact.mime_type,
-              size: markdownArtifact.size,
-            }}
-            artifacts={[htmlArtifact]}
-            accessToken="token"
-            onClose={() => {}}
-          />
-        </LocaleProvider>,
-      )
-    })
-
-    await waitForPreviewWork(() => (
-      container.querySelector('iframe[data-preview-renderer="artifact-html-preview"]') !== null
-    ))
-
-    const fetchUrls = vi.mocked(globalThis.fetch).mock.calls.map(([input]) => fetchInputUrl(input))
-    expect(fetchUrls).toHaveLength(1)
-    expect(fetchUrls[0]).toMatch(/\/doc\.md$/)
-    expect(container.querySelector('iframe[data-preview-renderer="artifact-html-preview"]')?.getAttribute('title')).toBe('preview.html')
-
-    act(() => {
-      root.unmount()
-    })
-    container.remove()
+    expect(html).toContain('data-artifact-html-preview="preview.html"')
+    expect(html).toContain('data-title="preview.html"')
   })
 })

--- a/src/apps/web/src/__tests__/documentPanelPreview.test.tsx
+++ b/src/apps/web/src/__tests__/documentPanelPreview.test.tsx
@@ -25,11 +25,16 @@ function flushMicrotasks(): Promise<void> {
     .then(() => Promise.resolve())
 }
 
-async function flushPreviewWork(): Promise<void> {
-  for (let i = 0; i < 8; i++) {
-    await flushMicrotasks()
-    await new Promise((resolve) => setTimeout(resolve, 0))
+async function waitForPreviewWork(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 40; i++) {
+    if (predicate()) return
+    await act(async () => {
+      await flushMicrotasks()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
   }
+  if (predicate()) return
+  throw new Error('preview did not settle')
 }
 
 describe('ResourcePreviewPanel artifact preview', () => {
@@ -124,9 +129,10 @@ describe('ResourcePreviewPanel artifact preview', () => {
       )
     })
 
-    await act(async () => {
-      await flushPreviewWork()
-    })
+    await waitForPreviewWork(() => (
+      vi.mocked(globalThis.fetch).mock.calls.length >= 2 &&
+      container.querySelector('iframe') !== null
+    ))
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(2)
     expect(container.querySelector('iframe')).not.toBeNull()

--- a/src/apps/web/src/components/ChatInput.tsx
+++ b/src/apps/web/src/components/ChatInput.tsx
@@ -761,16 +761,12 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
     return () => cancelAnimationFrame(id)
   }, [persistSelectedPersona, searchMode, selectedPersonaKey])
 
-  // sync persona when appMode changes
-  useEffect(() => {
-    const id = requestAnimationFrame(() => {
-      if (appMode === 'work' && selectedPersonaKey !== WORK_PERSONA_KEY) {
-        persistSelectedPersona(WORK_PERSONA_KEY)
-      } else if (appMode !== 'work' && selectedPersonaKey === WORK_PERSONA_KEY) {
-        persistSelectedPersona(DEFAULT_PERSONA_KEY)
-      }
-    })
-    return () => cancelAnimationFrame(id)
+  useLayoutEffect(() => {
+    if (appMode === 'work' && selectedPersonaKey !== WORK_PERSONA_KEY) {
+      persistSelectedPersona(WORK_PERSONA_KEY)
+    } else if (appMode !== 'work' && selectedPersonaKey === WORK_PERSONA_KEY) {
+      persistSelectedPersona(DEFAULT_PERSONA_KEY)
+    }
   }, [persistSelectedPersona, appMode, selectedPersonaKey])
 
   const typewriterTarget = placeholder

--- a/src/apps/web/src/components/ChatView.tsx
+++ b/src/apps/web/src/components/ChatView.tsx
@@ -3061,6 +3061,7 @@ export const ChatView = memo(function ChatView() {
 
   const chatInputEl = useMemo(() => (
     <ChatInput
+      key={`${threadId ?? '__no_thread__'}:${effectiveAppMode}:${isSearchThread ? 'search' : 'default'}`}
       ref={chatInputRef}
       onSubmit={handleSend}
       onCancel={handleCancel}

--- a/src/apps/web/src/components/ChatView.tsx
+++ b/src/apps/web/src/components/ChatView.tsx
@@ -3061,7 +3061,6 @@ export const ChatView = memo(function ChatView() {
 
   const chatInputEl = useMemo(() => (
     <ChatInput
-      key={`${threadId ?? '__no_thread__'}:${effectiveAppMode}:${isSearchThread ? 'search' : 'default'}`}
       ref={chatInputRef}
       onSubmit={handleSend}
       onCancel={handleCancel}
@@ -3415,7 +3414,7 @@ export const ChatView = memo(function ChatView() {
   ])
 
   return (
-    <div ref={chatViewRootRef} className="theme-surface-page relative flex min-w-0 flex-1 overflow-hidden bg-[var(--c-bg-page)]">
+    <div ref={chatViewRootRef} className="theme-surface-page theme-chat-surface relative flex min-w-0 flex-1 overflow-hidden bg-[var(--c-bg-page)]">
       {/* Chat column + right panel: starts below the desktop Chat/Work titlebar. */}
       <div className="relative flex flex-1 min-h-0 min-w-0">
         <div
@@ -3427,7 +3426,7 @@ export const ChatView = memo(function ChatView() {
           } as React.CSSProperties}
         >
           <ChatTitleMenu />
-          <div className="pointer-events-none absolute inset-x-0 top-[60px] z-10 h-10" style={{ background: 'linear-gradient(to bottom, var(--c-bg-page-gradient-stop, var(--c-bg-page)), transparent)' }} />
+          <div className="pointer-events-none absolute inset-x-0 top-[60px] z-10 h-10" style={{ background: 'linear-gradient(to bottom, var(--c-chat-bg-gradient-stop, var(--c-bg-page-gradient-stop, var(--c-bg-page))), transparent)' }} />
           {/* 消息列表 */}
           {messageListArea}
 
@@ -3447,7 +3446,7 @@ export const ChatView = memo(function ChatView() {
           left: 0,
           right: 0,
           zIndex: 10,
-          background: 'linear-gradient(to bottom, transparent 0%, var(--c-bg-page-gradient-stop, var(--c-bg-page)) 24px)',
+          background: 'linear-gradient(to bottom, transparent 0%, var(--c-chat-bg-gradient-stop, var(--c-bg-page-gradient-stop, var(--c-bg-page))) 24px)',
           transition: `padding ${rightPanelLayoutTransitionCss}`,
         } as React.CSSProperties}
         className="flex w-full flex-col items-center gap-2"

--- a/src/apps/web/src/components/DesktopSettings.tsx
+++ b/src/apps/web/src/components/DesktopSettings.tsx
@@ -585,7 +585,7 @@ export function DesktopSettings({
   return (
     <>
       <motion.div
-        className="flex h-full min-h-0 min-w-0 flex-1 overflow-hidden"
+        className="theme-surface-page flex h-full min-h-0 min-w-0 flex-1 overflow-hidden bg-[var(--c-bg-page)]"
         style={settingsMotionStyle}
         initial={{ opacity: 0, x: 10 }}
         animate={{ opacity: 1, x: 0 }}
@@ -594,7 +594,7 @@ export function DesktopSettings({
         onAnimationComplete={handleMotionComplete}
       >
         <div
-          className="flex w-[280px] shrink-0 flex-col overflow-y-auto py-4"
+          className="theme-surface-sidebar flex w-[280px] shrink-0 flex-col overflow-y-auto bg-[var(--c-bg-sidebar)] py-4"
           style={{
             borderRight: "0.5px solid var(--c-border-subtle)",
             transform: "translateZ(0)",
@@ -620,7 +620,7 @@ export function DesktopSettings({
           <div
             className="pointer-events-none absolute left-0 right-0 top-0 z-10 h-8 transition-opacity duration-200"
             style={{
-              background: 'linear-gradient(to bottom, var(--c-bg-page) 0%, transparent 100%)',
+              background: 'linear-gradient(to bottom, var(--c-bg-page-gradient-stop, var(--c-bg-page)) 0%, transparent 100%)',
               opacity: scrolled ? 1 : 0,
             }}
           />

--- a/src/apps/web/src/components/DesktopTitleBar.tsx
+++ b/src/apps/web/src/components/DesktopTitleBar.tsx
@@ -29,7 +29,7 @@ import { secondaryButtonSmCls, secondaryButtonBorderStyle } from './buttonStyles
 export const DESKTOP_TITLEBAR_HEIGHT = 44
 const WINDOWS_TITLEBAR_HEIGHT = 44
 const MAC_TITLEBAR_LEFT_PADDING = 76
-const DESKTOP_ICON_RAIL_LEFT_PADDING = 8
+const DESKTOP_ICON_RAIL_LEFT_PADDING = 12
 
 type Props = {
   sidebarCollapsed: boolean

--- a/src/apps/web/src/components/SettingsModal.tsx
+++ b/src/apps/web/src/components/SettingsModal.tsx
@@ -86,7 +86,7 @@ export function SettingsModal({ me, accessToken, initialTab = 'account', onClose
       onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
       <div
-        className="modal-enter flex overflow-hidden rounded-2xl shadow-2xl bg-[var(--c-bg-page)]"
+        className="theme-surface-page modal-enter flex overflow-hidden rounded-2xl bg-[var(--c-bg-page)] shadow-2xl"
         style={{
           width: '832px',
           height: '624px',
@@ -95,7 +95,7 @@ export function SettingsModal({ me, accessToken, initialTab = 'account', onClose
       >
         {/* nav */}
         <div
-          className="flex w-[200px] shrink-0 flex-col py-4 bg-[var(--c-bg-sidebar)]"
+          className="theme-surface-sidebar flex w-[200px] shrink-0 flex-col bg-[var(--c-bg-sidebar)] py-4"
           style={{ borderRight: '0.5px solid rgba(0,0,0,0.14)' }}
         >
           <div className="mb-2 px-4 py-1">

--- a/src/apps/web/src/components/Sidebar.tsx
+++ b/src/apps/web/src/components/Sidebar.tsx
@@ -37,7 +37,7 @@ import {
   readGtdSomedayThreadIds, writeGtdSomedayThreadIds,
   readGtdArchivedThreadIds, writeGtdArchivedThreadIds,
   readPinnedThreadIds, writePinnedThreadIds,
-  readGtdEnabled, readExpandedProjectPaths, writeExpandedProjectPaths,
+  readGtdEnabled, readExpandedProjectPaths, subscribeGtdEnabled, writeExpandedProjectPaths,
   clearThreadWorkFolder, readThreadWorkFolder, writeThreadWorkFolder, clearWorkFolder, writeWorkFolder,
 } from '../storage'
 
@@ -58,7 +58,6 @@ const PROJECT_GROUP_SECONDARY_PAGE_SIZE = 2
 const PROJECT_GROUP_LABEL_WEIGHT = 'var(--c-sidebar-thread-weight)'
 const SIDEBAR_ROW_TEXT_SIZE = '13.5px'
 const SIDEBAR_ROW_LINE_HEIGHT = '20px'
-const GTD_ENABLED_STORAGE_KEY = 'arkloop:web:gtd_enabled'
 const DRAG_START_DISTANCE_PX = 3
 const DRAG_LONG_PRESS_DELAY_MS = 180
 const GTD_BUCKETS: readonly GtdBucket[] = ['inbox', 'todo', 'waiting', 'someday', 'archived']
@@ -1127,20 +1126,7 @@ export function Sidebar({
   }, [deleteConfirmThreadId])
 
   useEffect(() => {
-    const handler = (e: Event) => {
-      const enabled = (e as CustomEvent<boolean>).detail
-      setGtdEnabled(enabled)
-    }
-    const storageHandler = (e: StorageEvent) => {
-      if (e.key !== GTD_ENABLED_STORAGE_KEY) return
-      setGtdEnabled(e.newValue === 'true')
-    }
-    window.addEventListener('arkloop:gtd-enabled-changed', handler)
-    window.addEventListener('storage', storageHandler)
-    return () => {
-      window.removeEventListener('arkloop:gtd-enabled-changed', handler)
-      window.removeEventListener('storage', storageHandler)
-    }
+    return subscribeGtdEnabled(setGtdEnabled)
   }, [])
 
   // 监听 work folder 变更，触发重新渲染

--- a/src/apps/web/src/components/WelcomePage.tsx
+++ b/src/apps/web/src/components/WelcomePage.tsx
@@ -502,7 +502,7 @@ export function WelcomePage() {
 
   return (
     <div className="flex h-full min-w-0 overflow-hidden">
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+      <div className="theme-surface-page theme-chat-surface flex min-h-0 min-w-0 flex-1 flex-col bg-[var(--c-bg-page)]">
         {/* 顶部 header */}
         <div className="relative z-10 flex min-h-[51px] items-center justify-end gap-2 px-[15px] py-[15px]">
           {!isDesktop() && (

--- a/src/apps/web/src/components/settings/AdvancedSettings.tsx
+++ b/src/apps/web/src/components/settings/AdvancedSettings.tsx
@@ -125,13 +125,7 @@ function normalizeThemeBackgroundImage(value: unknown): ThemeBackgroundImage | n
 
 function applySidebarGrouping(value: unknown): void {
   if (value !== 'normal' && value !== 'gtd') return
-  const enabled = value === 'gtd'
-  writeGtdEnabled(enabled)
-  window.dispatchEvent(new CustomEvent('arkloop:gtd-enabled-changed', { detail: enabled }))
-  window.dispatchEvent(new StorageEvent('storage', {
-    key: 'arkloop:web:gtd_enabled',
-    newValue: String(enabled),
-  }))
+  writeGtdEnabled(value === 'gtd')
 }
 
 function formatUsd(value: number) {

--- a/src/apps/web/src/components/settings/AdvancedSettings.tsx
+++ b/src/apps/web/src/components/settings/AdvancedSettings.tsx
@@ -32,7 +32,8 @@ import type { MeDailyUsageItem, MeHourlyUsageItem, MeModelUsageItem, MeUsageSumm
 import { getMyDailyUsage, getMyHourlyUsage, getMyUsage, getMyUsageByModel } from '../../api'
 import { useAppearance } from '../../contexts/AppearanceContext'
 import { useLocale } from '../../contexts/LocaleContext'
-import type { ThemeDefinition } from '../../themes/types'
+import type { ThemeBackgroundImage, ThemeDefinition, ThemePreset } from '../../themes/types'
+import { readGtdEnabled, writeGtdEnabled } from '../../storage'
 import { SettingsSection } from './_SettingsSection'
 import { SettingsSectionHeader } from './_SettingsSectionHeader'
 import { settingsInputCls } from './_SettingsInput'
@@ -78,6 +79,7 @@ const DESKTOP_EXPORT_SECTIONS: DesktopExportSection[] = [
 
 const AGENT_IMPORT_ITEM_KEYS = ['identity', 'skills', 'mcp', 'providers'] as const
 const AGENT_IMPORT_SOURCE_ORDER: ImportSourceKind[] = ['openclaw', 'hermes']
+const THEME_PRESETS: readonly ThemePreset[] = ['default', 'terra', 'github', 'nord', 'catppuccin', 'tokyo-night', 'retina-burn', 'background-image', 'custom']
 
 function createDefaultAgentImportSelection(): Record<ImportItemKey, boolean> {
   return {
@@ -93,6 +95,43 @@ function createAgentImportSelections(sources: AgentImportDiscovery[]): AgentImpo
     acc[source.kind] = createDefaultAgentImportSelection()
     return acc
   }, {})
+}
+
+function isThemePreset(value: unknown): value is ThemePreset {
+  return typeof value === 'string' && THEME_PRESETS.includes(value as ThemePreset)
+}
+
+function normalizeThemeBackgroundImage(value: unknown): ThemeBackgroundImage | null | undefined {
+  if (value === null) return null
+  if (!value || typeof value !== 'object') return undefined
+  const image = value as Record<string, unknown>
+  if (
+    typeof image.dataUrl !== 'string' ||
+    typeof image.name !== 'string' ||
+    typeof image.mimeType !== 'string' ||
+    typeof image.size !== 'number' ||
+    typeof image.updatedAt !== 'number'
+  ) {
+    return undefined
+  }
+  return {
+    dataUrl: image.dataUrl,
+    name: image.name,
+    mimeType: image.mimeType,
+    size: image.size,
+    updatedAt: image.updatedAt,
+  }
+}
+
+function applySidebarGrouping(value: unknown): void {
+  if (value !== 'normal' && value !== 'gtd') return
+  const enabled = value === 'gtd'
+  writeGtdEnabled(enabled)
+  window.dispatchEvent(new CustomEvent('arkloop:gtd-enabled-changed', { detail: enabled }))
+  window.dispatchEvent(new StorageEvent('storage', {
+    key: 'arkloop:web:gtd_enabled',
+    newValue: String(enabled),
+  }))
 }
 
 function formatUsd(value: number) {
@@ -962,7 +1001,18 @@ function DataPane({ onReloadOverview }: { onReloadOverview: () => Promise<void> 
   const ob = t.onboarding
   const api = getDesktopApi()
   const { addToast } = useToast()
-  const { customThemeId, customThemes, saveCustomTheme, setActiveCustomTheme } = useAppearance()
+  const {
+    themePreset,
+    setThemePreset,
+    customThemeId,
+    customThemes,
+    saveCustomTheme,
+    setActiveCustomTheme,
+    backgroundImage,
+    setBackgroundImage,
+    backgroundImageOpacity,
+    setBackgroundImageOpacity,
+  } = useAppearance()
   const [actionLoading, setActionLoading] = useState<'choose' | 'export' | 'import' | null>(null)
   const [actionError, setActionError] = useState('')
   const [exportDialogOpen, setExportDialogOpen] = useState(false)
@@ -1034,8 +1084,12 @@ function DataPane({ onReloadOverview }: { onReloadOverview: () => Promise<void> 
       const result = await api.advanced.exportDataBundle({
         sections: selectedSections,
         themes: {
+          themePreset,
           customThemeId,
           customThemes: selectedSections.includes('themes') ? customThemes : {},
+          backgroundImage: selectedSections.includes('themes') ? backgroundImage : null,
+          backgroundImageOpacity: selectedSections.includes('themes') ? backgroundImageOpacity : null,
+          sidebarGrouping: selectedSections.includes('themes') ? (readGtdEnabled() ? 'gtd' : 'normal') : null,
         },
       })
       if (result.canceled) {
@@ -1050,7 +1104,7 @@ function DataPane({ onReloadOverview }: { onReloadOverview: () => Promise<void> 
     } finally {
       setActionLoading(null)
     }
-  }, [api, addToast, customThemeId, customThemes, ds.advancedExportCanceled, ds.advancedExportDone, selectedSections, t.requestFailed])
+  }, [api, addToast, backgroundImage, backgroundImageOpacity, customThemeId, customThemes, ds.advancedExportCanceled, ds.advancedExportDone, selectedSections, t.requestFailed, themePreset])
 
   const handleImport = useCallback(async () => {
     if (!api?.advanced) return
@@ -1062,15 +1116,38 @@ function DataPane({ onReloadOverview }: { onReloadOverview: () => Promise<void> 
         addToast(ds.advancedImportCanceled, 'neutral')
         return
       }
-      if (result.themes?.customThemes && typeof result.themes.customThemes === 'object') {
-        for (const value of Object.values(result.themes.customThemes)) {
+      const importedThemes = result.themes
+      if (importedThemes?.customThemes && typeof importedThemes.customThemes === 'object') {
+        for (const value of Object.values(importedThemes.customThemes)) {
           if (value && typeof value === 'object' && 'id' in value && typeof value.id === 'string') {
             saveCustomTheme(value as ThemeDefinition)
           }
         }
-        if (result.themes.customThemeId) {
-          setActiveCustomTheme(result.themes.customThemeId)
+      }
+      let importedBackground: ThemeBackgroundImage | null | undefined
+      if (importedThemes && 'backgroundImage' in importedThemes) {
+        importedBackground = normalizeThemeBackgroundImage(importedThemes.backgroundImage)
+        if (importedBackground === undefined) {
+          throw new Error(t.requestFailed)
         }
+      }
+      if (importedBackground !== undefined && !setBackgroundImage(importedBackground)) {
+        throw new Error(t.requestFailed)
+      }
+      if (typeof importedThemes?.backgroundImageOpacity === 'number' && Number.isFinite(importedThemes.backgroundImageOpacity)) {
+        setBackgroundImageOpacity(importedThemes.backgroundImageOpacity)
+      }
+      applySidebarGrouping(importedThemes?.sidebarGrouping)
+      if (isThemePreset(importedThemes?.themePreset)) {
+        if (importedThemes.themePreset === 'custom' && importedThemes.customThemeId) {
+          setActiveCustomTheme(importedThemes.customThemeId)
+        } else if (importedThemes.themePreset === 'background-image') {
+          setThemePreset('background-image')
+        } else {
+          setThemePreset(importedThemes.themePreset)
+        }
+      } else if (importedThemes?.customThemeId) {
+        setActiveCustomTheme(importedThemes.customThemeId)
       }
       addToast(ds.advancedImportDone, 'success')
       await onReloadOverview()
@@ -1079,7 +1156,7 @@ function DataPane({ onReloadOverview }: { onReloadOverview: () => Promise<void> 
     } finally {
       setActionLoading(null)
     }
-  }, [api, addToast, ds.advancedImportCanceled, ds.advancedImportDone, onReloadOverview, saveCustomTheme, setActiveCustomTheme, t.requestFailed])
+  }, [api, addToast, ds.advancedImportCanceled, ds.advancedImportDone, onReloadOverview, saveCustomTheme, setActiveCustomTheme, setBackgroundImage, setBackgroundImageOpacity, setThemePreset, t.requestFailed])
 
   const selectedAgentImportSource = selectedAgentImport
     ? agentImportSources.find((source) => source.kind === selectedAgentImport) ?? null

--- a/src/apps/web/src/components/settings/AppearanceSettings.tsx
+++ b/src/apps/web/src/components/settings/AppearanceSettings.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import type { LucideIcon } from 'lucide-react'
 import { Monitor, Sun, Moon } from 'lucide-react'
 import type { Locale } from '../../locales'
 import type { Theme } from '@arkloop/shared/contexts/theme'
 import { useLocale } from '../../contexts/LocaleContext'
 import { useTheme } from '../../contexts/ThemeContext'
-import { readGtdEnabled, writeGtdEnabled } from '../../storage'
+import { readGtdEnabled, subscribeGtdEnabled, writeGtdEnabled } from '../../storage'
 import { FontSettings } from './FontSettings'
 import { ThemePresetPicker } from './ThemePresetPicker'
 import { ThemeColorEditor } from './ThemeColorEditor'
@@ -267,6 +267,8 @@ export function SidebarGroupingPicker({ showLabel = true }: { showLabel?: boolea
   const [gtdEnabled, setGtdEnabled] = useState(() => readGtdEnabled())
   const [hoveredValue, setHoveredValue] = useState<boolean | null>(null)
 
+  useEffect(() => subscribeGtdEnabled(setGtdEnabled), [])
+
   const options: { value: boolean; label: string; Preview: () => React.JSX.Element }[] = [
     { value: false, label: t.sidebarGroupingNormal, Preview: NormalPreview },
     { value: true, label: t.sidebarGroupingGtd, Preview: GtdPreview },
@@ -294,11 +296,6 @@ export function SidebarGroupingPicker({ showLabel = true }: { showLabel?: boolea
                 if (gtdEnabled === value) return
                 setGtdEnabled(value)
                 writeGtdEnabled(value)
-                window.dispatchEvent(new CustomEvent('arkloop:gtd-enabled-changed', { detail: value }))
-                window.dispatchEvent(new StorageEvent('storage', {
-                  key: 'arkloop:web:gtd_enabled',
-                  newValue: String(value),
-                }))
               }}
               className="flex flex-col items-center gap-2"
             >

--- a/src/apps/web/src/components/settings/DesktopQQSettingsPanel.tsx
+++ b/src/apps/web/src/components/settings/DesktopQQSettingsPanel.tsx
@@ -68,6 +68,7 @@ export function DesktopQQSettingsPanel({
   const [onebotWSUrl, setOnebotWSUrl] = useState((channel?.config_json?.onebot_ws_url as string | undefined) ?? '')
   const [onebotHTTPUrl, setOnebotHTTPUrl] = useState((channel?.config_json?.onebot_http_url as string | undefined) ?? '')
   const [onebotToken, setOnebotToken] = useState((channel?.config_json?.onebot_token as string | undefined) ?? '')
+  const [botName, setBotName] = useState((channel?.config_json?.bot_name as string | undefined) ?? '')
   const [autoLoginUin, setAutoLoginUin] = useState((channel?.config_json?.auto_login_uin as string | undefined) ?? '')
   const refreshBindings = useCallback(async () => {
     if (!channel?.id) {
@@ -92,6 +93,7 @@ export function DesktopQQSettingsPanel({
     setOnebotWSUrl((channel?.config_json?.onebot_ws_url as string | undefined) ?? '')
     setOnebotHTTPUrl((channel?.config_json?.onebot_http_url as string | undefined) ?? '')
     setOnebotToken((channel?.config_json?.onebot_token as string | undefined) ?? '')
+    setBotName((channel?.config_json?.bot_name as string | undefined) ?? '')
     setAutoLoginUin((channel?.config_json?.auto_login_uin as string | undefined) ?? '')
   }, [channel, personas])
 
@@ -127,6 +129,7 @@ export function DesktopQQSettingsPanel({
   const persistedOnebotWSUrl = (channel?.config_json?.onebot_ws_url as string | undefined) ?? ''
   const persistedOnebotHTTPUrl = (channel?.config_json?.onebot_http_url as string | undefined) ?? ''
   const persistedOnebotToken = (channel?.config_json?.onebot_token as string | undefined) ?? ''
+  const persistedBotName = (channel?.config_json?.bot_name as string | undefined) ?? ''
   const persistedAutoLoginUin = (channel?.config_json?.auto_login_uin as string | undefined) ?? ''
   const dirty = useMemo(() => {
     if ((channel?.is_active ?? false) !== enabled) return true
@@ -137,9 +140,11 @@ export function DesktopQQSettingsPanel({
     if (onebotWSUrl !== persistedOnebotWSUrl) return true
     if (onebotHTTPUrl !== persistedOnebotHTTPUrl) return true
     if (onebotToken !== persistedOnebotToken) return true
+    if (botName !== persistedBotName) return true
     if (autoLoginUin !== persistedAutoLoginUin) return true
     return false
   }, [
+    botName,
     channel,
     defaultModel,
     effectiveAllowedUserIDs,
@@ -156,6 +161,7 @@ export function DesktopQQSettingsPanel({
     persistedOnebotWSUrl,
     persistedOnebotHTTPUrl,
     persistedOnebotToken,
+    persistedBotName,
     autoLoginUin,
     persistedAutoLoginUin,
   ])
@@ -210,6 +216,8 @@ export function DesktopQQSettingsPanel({
       else delete configJSON.onebot_http_url
       if (onebotToken.trim()) configJSON.onebot_token = onebotToken.trim()
       else delete configJSON.onebot_token
+      if (botName.trim()) configJSON.bot_name = botName.trim()
+      else delete configJSON.bot_name
       if (autoLoginUin.trim()) configJSON.auto_login_uin = autoLoginUin.trim()
       else delete configJSON.auto_login_uin
 
@@ -402,6 +410,16 @@ export function DesktopQQSettingsPanel({
                 value={onebotToken}
                 placeholder={ct.qqOneBotTokenPlaceholder}
                 onChange={(v) => { setOnebotToken(v); setSaved(false) }}
+              />
+            </ChannelDetailRow>
+            <ChannelDetailRow label={ct.qqBotName}>
+              <input
+                type="text"
+                value={botName}
+                onChange={(e) => { setBotName(e.target.value); setSaved(false) }}
+                placeholder={ct.qqBotNamePlaceholder}
+                disabled={saving}
+                className={inputCls}
               />
             </ChannelDetailRow>
             {/* access control card */}

--- a/src/apps/web/src/components/settings/DesktopQQSettingsPanel.tsx
+++ b/src/apps/web/src/components/settings/DesktopQQSettingsPanel.tsx
@@ -422,31 +422,21 @@ export function DesktopQQSettingsPanel({
                 className={inputCls}
               />
             </ChannelDetailRow>
-            {/* access control card */}
-            <div className="md:col-span-2">
-              <div
-                className="relative px-5 py-4"
-                style={{ border: '0.5px solid var(--c-border-subtle)', background: 'var(--c-bg-page)' }}
-              >
-                <div className="mb-4">
-                  <div className="text-sm font-medium text-[var(--c-text-heading)]">{ct.accessControl}</div>
-                </div>
-
-                <div className="mb-4">
-                  <ListField
-                    label={ct.qqAllowedUsers}
-                    values={allowedUserIDs}
-                    inputValue={allowedUserInput}
-                    placeholder={ct.qqAllowedUsersPlaceholder}
-                    addLabel={t.skills.add}
-                    onInputChange={setAllowedUserInput}
-                    onAdd={handleAddAllowedUsers}
-                    onRemove={(value) => {
-                      setAllowedUserIDs((current) => current.filter((item) => item !== value))
-                      setSaved(false)
-                    }}
-                  />
-                </div>
+            <ChannelDetailRow label={ct.accessControl}>
+              <div className="flex flex-col gap-4">
+                <ListField
+                  label={ct.qqAllowedUsers}
+                  values={allowedUserIDs}
+                  inputValue={allowedUserInput}
+                  placeholder={ct.qqAllowedUsersPlaceholder}
+                  addLabel={t.skills.add}
+                  onInputChange={setAllowedUserInput}
+                  onAdd={handleAddAllowedUsers}
+                  onRemove={(value) => {
+                    setAllowedUserIDs((current) => current.filter((item) => item !== value))
+                    setSaved(false)
+                  }}
+                />
 
                 <ListField
                   label={ct.qqAllowedGroups}
@@ -462,7 +452,7 @@ export function DesktopQQSettingsPanel({
                   }}
                 />
               </div>
-            </div>
+            </ChannelDetailRow>
 
             <div className="md:col-span-2">
               <label className="mb-1.5 block text-xs font-medium text-[var(--c-text-secondary)]">

--- a/src/apps/web/src/index.css
+++ b/src/apps/web/src/index.css
@@ -92,6 +92,7 @@ button:not(:disabled) {
   --c-background-image-scrim-alpha: calc(0.18 + ((1 - var(--c-background-image-opacity)) * 0.34));
   --c-background-image-vignette-alpha: 0.22;
   --c-bg-page-gradient-stop: var(--c-bg-page);
+  --c-chat-bg-gradient-stop: var(--c-bg-page-gradient-stop);
   --c-bg-sidebar: #242422;
   --c-bg-deep: #141413;
   --c-bg-sub: #1e1e1c;
@@ -1682,6 +1683,14 @@ button:not(:disabled) {
 
   :root[data-background-image="custom"] .theme-surface-page .theme-surface-page {
     background-color: transparent;
+  }
+
+  :root[data-background-image="custom"] {
+    --c-chat-bg-gradient-stop: color-mix(in srgb, var(--c-bg-page) 42%, transparent);
+  }
+
+  :root[data-background-image="custom"] .theme-chat-surface {
+    background-color: color-mix(in srgb, var(--c-bg-page) 42%, transparent);
   }
 }
 

--- a/src/apps/web/src/locales/en.ts
+++ b/src/apps/web/src/locales/en.ts
@@ -812,6 +812,8 @@ export const en: LocaleStrings = {
     qqOneBotHTTPUrlPlaceholder: 'http://127.0.0.1:3000',
     qqOneBotToken: 'Token',
     qqOneBotTokenPlaceholder: 'Access token',
+    qqBotName: 'Bot name',
+    qqBotNamePlaceholder: 'Chiffon',
     qqOneBotAutoFilled: 'Auto-filled from NapCat',
     qqExternalOneBotHint: 'Please deploy NapCat or another OneBot11 service externally, then fill in the connection info below',
     bindingsTitle: 'Linked accounts',

--- a/src/apps/web/src/locales/index.ts
+++ b/src/apps/web/src/locales/index.ts
@@ -813,6 +813,8 @@ export interface LocaleStrings {
     qqOneBotHTTPUrlPlaceholder: string
     qqOneBotToken: string
     qqOneBotTokenPlaceholder: string
+    qqBotName: string
+    qqBotNamePlaceholder: string
     qqOneBotAutoFilled: string
     qqExternalOneBotHint: string
     weixin: string

--- a/src/apps/web/src/locales/zh.ts
+++ b/src/apps/web/src/locales/zh.ts
@@ -806,6 +806,8 @@ export const zh: LocaleStrings = {
     qqOneBotHTTPUrlPlaceholder: 'http://127.0.0.1:3000',
     qqOneBotToken: 'Token',
     qqOneBotTokenPlaceholder: '鉴权 Token',
+    qqBotName: 'Bot 名称',
+    qqBotNamePlaceholder: '草洛',
     qqOneBotAutoFilled: '已从 NapCat 自动填充',
     qqExternalOneBotHint: '当前平台不支持内置 QQ 管理，请自行部署 NapCat 或其他 OneBot11 服务后填写连接信息',
     bindingsTitle: '已关联账号',

--- a/src/apps/web/src/storage.ts
+++ b/src/apps/web/src/storage.ts
@@ -2482,12 +2482,13 @@ export function writeBackgroundImageOpacityToStorage(opacity: number): void {
 
 // -- Sidebar View & GTD --
 
-const GTD_ENABLED_KEY = 'arkloop:web:gtd_enabled'
+export const GTD_ENABLED_STORAGE_KEY = 'arkloop:web:gtd_enabled'
+const GTD_ENABLED_CHANGED_EVENT = 'arkloop:gtd-enabled-changed'
 
 export function readGtdEnabled(): boolean {
   if (!canUseLocalStorage()) return false
   try {
-    return localStorage.getItem(GTD_ENABLED_KEY) === 'true'
+    return localStorage.getItem(GTD_ENABLED_STORAGE_KEY) === 'true'
   } catch {
     return false
   }
@@ -2496,8 +2497,32 @@ export function readGtdEnabled(): boolean {
 export function writeGtdEnabled(v: boolean): void {
   if (!canUseLocalStorage()) return
   try {
-    localStorage.setItem(GTD_ENABLED_KEY, String(v))
+    localStorage.setItem(GTD_ENABLED_STORAGE_KEY, String(v))
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent(GTD_ENABLED_CHANGED_EVENT, { detail: v }))
+    }
   } catch { /* ignore */ }
+}
+
+export function subscribeGtdEnabled(listener: (enabled: boolean) => void): () => void {
+  if (typeof window === 'undefined') return () => {}
+
+  const customHandler = (event: Event) => {
+    const enabled = (event as CustomEvent<boolean>).detail
+    listener(typeof enabled === 'boolean' ? enabled : readGtdEnabled())
+  }
+  const storageHandler = (event: StorageEvent) => {
+    if (event.key !== GTD_ENABLED_STORAGE_KEY) return
+    listener(event.newValue === 'true')
+  }
+
+  window.addEventListener(GTD_ENABLED_CHANGED_EVENT, customHandler)
+  window.addEventListener('storage', storageHandler)
+
+  return () => {
+    window.removeEventListener(GTD_ENABLED_CHANGED_EVENT, customHandler)
+    window.removeEventListener('storage', storageHandler)
+  }
 }
 
 const GTD_INBOX_THREAD_IDS_KEY = 'arkloop:web:gtd_inbox_thread_ids'

--- a/src/services/api/internal/http/accountapi/channels_qq.go
+++ b/src/services/api/internal/http/accountapi/channels_qq.go
@@ -403,6 +403,35 @@ func (c *qqConnector) HandleEvent(ctx context.Context, traceID string, ch data.C
 	// --- 群聊命令路径 ---
 	if !isPrivate {
 		cmdText := stripLeadingMention(text)
+		if cmd, ok := telegramCommandBase(cmdText, ""); ok && cmd == "/bind" {
+			parts := strings.Fields(cmdText)
+			replyText := "用法：/bind <code>"
+			if len(parts) >= 2 {
+				var bindErr error
+				replyText, bindErr = bindChannelIdentity(
+					ctx,
+					tx,
+					&ch,
+					identity,
+					parts[1],
+					"QQ",
+					c.channelBindCodesRepo,
+					c.channelIdentitiesRepo,
+					c.channelIdentityLinksRepo,
+					c.channelDMThreadsRepo,
+					c.threadRepo,
+				)
+				if bindErr != nil {
+					return bindErr
+				}
+			}
+			if err := commitTx(); err != nil {
+				return err
+			}
+			c.sendQQReply(ctx, cfg, "group", platformChatID, replyText)
+			return nil
+		}
+
 		_, replyText, _, cancelRunID, err := DispatchChannelCommand(
 			ctx, tx, ch, *persona, identity,
 			cmdText, false, platformChatID,
@@ -685,7 +714,7 @@ func (c *qqConnector) persistQQGroupPassiveMessage(
 				inboundLedgerKeyConversationType: incoming.ChatType,
 				inboundLedgerKeyMentionsBot:      incoming.MentionsBot,
 				inboundLedgerKeyIsReplyToBot:     incoming.IsReplyToBot,
-				"passive":           true,
+				"passive":                        true,
 			}, inboundStatePassivePersisted),
 		); err != nil {
 			return err

--- a/src/services/api/internal/http/catalogapi/tool_catalog_effective_runtime_providers.go
+++ b/src/services/api/internal/http/catalogapi/tool_catalog_effective_runtime_providers.go
@@ -28,7 +28,10 @@ func loadEffectiveBuiltinProviders(
 		if err != nil {
 			return nil, err
 		}
-		providers = append(providers, sharedtoolruntime.ReadyProvidersFromStatuses(userStatuses)...)
+		providers = sharedtoolruntime.MergeProviderOverrides(
+			providers,
+			sharedtoolruntime.ReadyProvidersFromStatuses(userStatuses),
+		)
 	}
 	return providers, nil
 }

--- a/src/services/api/internal/http/catalogapi/tool_catalog_effective_runtime_providers_desktop.go
+++ b/src/services/api/internal/http/catalogapi/tool_catalog_effective_runtime_providers_desktop.go
@@ -14,13 +14,24 @@ import (
 func loadEffectiveBuiltinProviders(
 	ctx context.Context,
 	pool data.DB,
-	_ string,
-	_ *uuid.UUID,
+	ownerKind string,
+	ownerUserID *uuid.UUID,
 	decrypt sharedtoolruntime.ProviderSecretDecrypter,
 ) ([]sharedtoolruntime.ProviderConfig, error) {
 	platformStatuses, err := sharedtoolruntime.LoadPlatformProviderStatuses(ctx, pool, decrypt)
 	if err != nil {
 		return nil, err
 	}
-	return sharedtoolruntime.ReadyProvidersFromStatuses(platformStatuses), nil
+	providers := sharedtoolruntime.ReadyProvidersFromStatuses(platformStatuses)
+	if ownerKind == "user" && ownerUserID != nil {
+		userStatuses, err := sharedtoolruntime.LoadUserProviderStatuses(ctx, pool, *ownerUserID, decrypt)
+		if err != nil {
+			return nil, err
+		}
+		providers = sharedtoolruntime.MergeProviderOverrides(
+			providers,
+			sharedtoolruntime.ReadyProvidersFromStatuses(userStatuses),
+		)
+	}
+	return providers, nil
 }

--- a/src/services/shared/toolruntime/provider_loader.go
+++ b/src/services/shared/toolruntime/provider_loader.go
@@ -81,6 +81,31 @@ func ReadyProvidersFromStatuses(statuses []ProviderRuntimeStatus) []ProviderConf
 	return out
 }
 
+func MergeProviderOverrides(base []ProviderConfig, overrides []ProviderConfig) []ProviderConfig {
+	out := copyProviders(base)
+	indexByGroup := make(map[string]int, len(out))
+	for idx, provider := range out {
+		groupName := strings.TrimSpace(provider.GroupName)
+		if groupName == "" {
+			continue
+		}
+		indexByGroup[groupName] = idx
+	}
+	for _, provider := range overrides {
+		groupName := strings.TrimSpace(provider.GroupName)
+		if groupName == "" {
+			continue
+		}
+		if idx, ok := indexByGroup[groupName]; ok {
+			out[idx] = provider
+			continue
+		}
+		indexByGroup[groupName] = len(out)
+		out = append(out, provider)
+	}
+	return out
+}
+
 func LoadPlatformProviderStatuses(ctx context.Context, pool providerQuerier, decrypt ProviderSecretDecrypter) ([]ProviderRuntimeStatus, error) {
 	return loadProviderStatuses(ctx, pool, `
 		SELECT c.owner_kind, c.group_name, c.provider_name, c.key_prefix, c.base_url, c.config_json,

--- a/src/services/worker/internal/app/composition_desktop.go
+++ b/src/services/worker/internal/app/composition_desktop.go
@@ -1051,12 +1051,12 @@ func desktopToolProviderBindings(db data.DesktopDB) pipeline.RunMiddleware {
 		if db == nil || rc == nil {
 			return next(ctx, rc)
 		}
-		platformCfgs, err := toolprovider.LoadDesktopActiveToolProviders(ctx, db)
+		platformCfgs, userCfgs, err := toolprovider.LoadDesktopActiveToolProviders(ctx, db, rc.Run.CreatedByUserID)
 		if err != nil {
 			slog.WarnContext(ctx, "desktop: failed to load tool providers, skipping", "err", err)
 			return next(ctx, rc)
 		}
-		if len(platformCfgs) == 0 {
+		if len(platformCfgs) == 0 && len(userCfgs) == 0 {
 			return next(ctx, rc)
 		}
 		if rc.ActiveToolProviderByGroup == nil {
@@ -1065,21 +1065,35 @@ func desktopToolProviderBindings(db data.DesktopDB) pipeline.RunMiddleware {
 		if rc.ActiveToolProviderConfigsByGroup == nil {
 			rc.ActiveToolProviderConfigsByGroup = map[string]sharedtoolruntime.ProviderConfig{}
 		}
-		apply := func(cfg toolprovider.ActiveProviderConfig) {
+		apply := func(cfg toolprovider.ActiveProviderConfig, override bool) {
 			g := strings.TrimSpace(cfg.GroupName)
 			pn := strings.TrimSpace(cfg.ProviderName)
 			if g == "" || pn == "" {
 				return
 			}
 			exec := pipeline.BuildProviderExecutor(cfg)
-			rc.ActiveToolProviderByGroup[g] = pn
-			rc.ActiveToolProviderConfigsByGroup[g] = toolprovider.ToRuntimeProviderConfig(cfg)
+			_, exists := rc.ActiveToolProviderByGroup[g]
+			if exists && override {
+				if nc, ok := exec.(tools.NotConfiguredChecker); ok && nc.IsNotConfigured() {
+					slog.WarnContext(ctx, "desktop: user tool provider not configured, keeping platform provider", "group_name", g, "provider_name", pn)
+					return
+				}
+			}
+			if !exists || override {
+				rc.ActiveToolProviderByGroup[g] = pn
+				rc.ActiveToolProviderConfigsByGroup[g] = toolprovider.ToRuntimeProviderConfig(cfg)
+			} else if rc.ActiveToolProviderByGroup[g] != pn {
+				slog.WarnContext(ctx, "desktop: duplicate active tool provider", "group_name", g, "provider_name", pn)
+			}
 			if exec != nil {
 				rc.ToolExecutors[pn] = exec
 			}
 		}
 		for _, cfg := range platformCfgs {
-			apply(cfg)
+			apply(cfg, false)
+		}
+		for _, cfg := range userCfgs {
+			apply(cfg, true)
 		}
 		return next(ctx, rc)
 	}

--- a/src/services/worker/internal/toolprovider/load_desktop.go
+++ b/src/services/worker/internal/toolprovider/load_desktop.go
@@ -77,10 +77,10 @@ func activeConfigsFromStatuses(statuses []sharedtoolruntime.ProviderRuntimeStatu
 	return out
 }
 
-// LoadDesktopActiveToolProviders returns active platform rows from SQLite.
-func LoadDesktopActiveToolProviders(ctx context.Context, db data.DesktopDB) ([]ActiveProviderConfig, error) {
+// LoadDesktopActiveToolProviders returns active platform and user rows from SQLite.
+func LoadDesktopActiveToolProviders(ctx context.Context, db data.DesktopDB, userID *uuid.UUID) ([]ActiveProviderConfig, []ActiveProviderConfig, error) {
 	if db == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	var keyRing *sharedencryption.KeyRing
@@ -105,7 +105,17 @@ func LoadDesktopActiveToolProviders(ctx context.Context, db data.DesktopDB) ([]A
 
 	platformStatuses, err := sharedtoolruntime.LoadPlatformProviderStatuses(ctx, db, decrypt)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return activeConfigsFromStatuses(platformStatuses), nil
+	platformProviders := activeConfigsFromStatuses(platformStatuses)
+
+	var userProviders []ActiveProviderConfig
+	if userID != nil && *userID != uuid.Nil {
+		userStatuses, err := sharedtoolruntime.LoadUserProviderStatuses(ctx, db, *userID, decrypt)
+		if err != nil {
+			return nil, nil, err
+		}
+		userProviders = activeConfigsFromStatuses(userStatuses)
+	}
+	return platformProviders, userProviders, nil
 }

--- a/src/services/worker/internal/toolprovider/load_desktop_test.go
+++ b/src/services/worker/internal/toolprovider/load_desktop_test.go
@@ -29,9 +29,12 @@ func TestLoadDesktopActiveToolProvidersIncludesDefaultExa(t *testing.T) {
 	})
 	db := sqlitepgx.New(sqlitePool.Unwrap())
 
-	platform, err := LoadDesktopActiveToolProviders(ctx, db)
+	platform, user, err := LoadDesktopActiveToolProviders(ctx, db, nil)
 	if err != nil {
 		t.Fatalf("load: %v", err)
+	}
+	if len(user) != 0 {
+		t.Fatalf("expected no user row, got %d", len(user))
 	}
 	if len(platform) != 1 {
 		t.Fatalf("expected 1 platform row, got %d", len(platform))
@@ -89,9 +92,12 @@ func TestLoadDesktopActiveToolProvidersPlatformRow(t *testing.T) {
 		t.Fatalf("insert tool_provider_configs: %v", err)
 	}
 
-	platform, err := LoadDesktopActiveToolProviders(ctx, db)
+	platform, user, err := LoadDesktopActiveToolProviders(ctx, db, nil)
 	if err != nil {
 		t.Fatalf("load: %v", err)
+	}
+	if len(user) != 0 {
+		t.Fatalf("expected no user row, got %d", len(user))
 	}
 	if len(platform) != 1 {
 		t.Fatalf("expected 1 platform row, got %d", len(platform))
@@ -176,9 +182,12 @@ func TestLoadDesktopActiveToolProvidersDecryptsWithEncryptionFile(t *testing.T) 
 		t.Fatalf("seed tool provider: %v", err)
 	}
 
-	platform, err := LoadDesktopActiveToolProviders(ctx, db)
+	platform, user, err := LoadDesktopActiveToolProviders(ctx, db, nil)
 	if err != nil {
 		t.Fatalf("load: %v", err)
+	}
+	if len(user) != 0 {
+		t.Fatalf("expected no user row, got %d", len(user))
 	}
 	var readProvider *ActiveProviderConfig
 	for idx := range platform {
@@ -197,5 +206,64 @@ func TestLoadDesktopActiveToolProvidersDecryptsWithEncryptionFile(t *testing.T) 
 	_, err = desktop.LoadEncryptionKeyRing(desktop.KeyRingOptions{})
 	if err != nil {
 		t.Fatalf("desktop key ring should load: %v", err)
+	}
+}
+
+func TestLoadDesktopActiveToolProvidersUserRows(t *testing.T) {
+	ctx := context.Background()
+	sqlitePool, err := sqliteadapter.AutoMigrate(ctx, filepath.Join(t.TempDir(), "loadtp-user.db"))
+	if err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = sqlitePool.Close()
+	})
+	db := sqlitepgx.New(sqlitePool.Unwrap())
+
+	accountID := uuid.MustParse("00000000-0000-4000-8000-000000000022")
+	userID := uuid.MustParse("00000000-0000-4000-8000-000000000021")
+	if _, err := db.Exec(ctx, `
+		INSERT INTO users (id, username, email, status)
+		VALUES ($1, 'u2', 'u2@test', 'active')
+		ON CONFLICT (id) DO NOTHING`, userID,
+	); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := db.Exec(ctx, `
+		INSERT INTO accounts (id, slug, name, type, owner_user_id)
+		VALUES ($1, 'a2', 'A2', 'personal', $2)
+		ON CONFLICT (id) DO NOTHING`, accountID, userID,
+	); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	if _, err := db.Exec(ctx, `
+		INSERT INTO tool_provider_configs (
+			account_id, owner_kind, owner_user_id, group_name, provider_name, is_active
+		) VALUES ($1, 'user', $2, 'web_search', 'web_search.basic', 1)`,
+		accountID, userID,
+	); err != nil {
+		t.Fatalf("insert user tool provider: %v", err)
+	}
+
+	platform, user, err := LoadDesktopActiveToolProviders(ctx, db, &userID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(platform) == 0 {
+		t.Fatal("expected platform default provider")
+	}
+	if len(user) != 1 {
+		t.Fatalf("expected 1 user row, got %d", len(user))
+	}
+	if user[0].OwnerKind != "user" || user[0].GroupName != "web_search" || user[0].ProviderName != "web_search.basic" {
+		t.Fatalf("unexpected user row: %+v", user[0])
+	}
+
+	_, none, err := LoadDesktopActiveToolProviders(ctx, db, nil)
+	if err != nil {
+		t.Fatalf("load without user: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("expected no user rows without user id, got %d", len(none))
 	}
 }


### PR DESCRIPTION
## Summary
- restore desktop data export/import for appearance state: theme preset, custom background image, opacity, and sidebar grouping
- restore desktop user-level tool provider loading for API catalog and worker runtime, with user provider overrides matching SaaS behavior
- keep existing chat/settings background surface fixes and QQ/channel behavior fixes in this branch

## Tests
- pnpm --dir src/apps/web type-check
- pnpm --dir src/apps/web test -- advancedSettings.test.tsx
- pnpm --dir src/apps/web test -- desktopChannelsSettings.test.tsx chatPageLoading.test.tsx chatInputPersonaSelector.test.tsx
- go test -tags desktop ./internal/toolprovider
- go test -tags desktop ./internal/http/catalogapi
- go test ./internal/http/accountapi
- go test ./toolruntime
- git diff --check

## Note
- `go test -tags desktop ./internal/app` still fails on existing `TestLoadDesktopRoutingConfigUsesReadOnlyTx`: expected an error but got nil.