### PR TITLE
fix(worker): align QQ envelope projection with Telegram format

### DIFF
--- a/src/services/worker/internal/pipeline/envelope_projection.go
+++ b/src/services/worker/internal/pipeline/envelope_projection.go
@@ -77,7 +77,7 @@ func formatNaturalPrefix(f *envelopeFields) string {
 	}
 	var prefix string
 	if f.MessageID != "" {
-		prefix = name + " (#" + f.MessageID + "):"
+		prefix = "[#" + f.MessageID + "] " + name + ":"
 	} else {
 		prefix = name + ":"
 	}

--- a/src/services/worker/internal/pipeline/envelope_projection_test.go
+++ b/src/services/worker/internal/pipeline/envelope_projection_test.go
@@ -87,7 +87,7 @@ func TestFormatNaturalPrefix_withReply(t *testing.T) {
 		Body:           "我同意",
 	}
 	got := formatNaturalPrefix(f)
-	want := "Alice (#42):\n[引用 #38] Bob: 昨天的方案不错 [/引用]\n我同意"
+	want := "[#42] Alice:\n[引用 #38] Bob: 昨天的方案不错 [/引用]\n我同意"
 	if got != want {
 		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
 	}
@@ -100,7 +100,7 @@ func TestFormatNaturalPrefix_noReply(t *testing.T) {
 		Body:        "Hello",
 	}
 	got := formatNaturalPrefix(f)
-	want := "Charlie (#99):\nHello"
+	want := "[#99] Charlie:\nHello"
 	if got != want {
 		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
 	}
@@ -138,7 +138,7 @@ func TestProjectGroupEnvelopes_mixedMessages(t *testing.T) {
 
 	// 第一条 user 消息应被投影
 	got := rc.Messages[0].Content[0].Text
-	want := "Alice (#12):\n[引用 #10] Bob: hi [/引用]\n回复内容"
+	want := "[#12] Alice:\n[引用 #10] Bob: hi [/引用]\n回复内容"
 	if got != want {
 		t.Fatalf("projected msg[0]:\n%s\nwant:\n%s", got, want)
 	}
@@ -171,7 +171,7 @@ func TestProjectGroupEnvelopes_escapedQuotes(t *testing.T) {
 	projectGroupEnvelopes(rc)
 
 	got := rc.Messages[0].Content[0].Text
-	want := "O\\\"Brien (#5):\nbody"
+	want := "[#5] O\\\"Brien:\nbody"
 	if got != want {
 		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
 	}

--- a/src/services/worker/internal/pipeline/mw_channel_admin_tag.go
+++ b/src/services/worker/internal/pipeline/mw_channel_admin_tag.go
@@ -34,7 +34,7 @@ func NewChannelAdminTagMiddleware(db data.DB) RunMiddleware {
 
 func isTelegramOrDiscordChannel(channelType string) bool {
 	ct := strings.ToLower(strings.TrimSpace(channelType))
-	return ct == "telegram" || ct == "discord"
+	return ct == "telegram" || ct == "discord" || ct == "qq" || ct == "qqbot"
 }
 
 // resolveAdminIdentityRefs 收集消息中所有 sender-ref，批量查出哪些是 admin。

--- a/src/services/worker/internal/pipeline/mw_channel_telegram_group_user_merge.go
+++ b/src/services/worker/internal/pipeline/mw_channel_telegram_group_user_merge.go
@@ -203,7 +203,7 @@ func compactTelegramGroupEnvelopeBurstOrderedParts(tail []llm.Message) ([]llm.Co
 		if !ok {
 			return nil, false
 		}
-		if !strings.EqualFold(strings.TrimSpace(meta["channel"]), "telegram") {
+		if !isGroupMergeEligibleChannel(strings.TrimSpace(meta["channel"])) {
 			return nil, false
 		}
 		body = compactTelegramEnvelopeBody(meta, body)
@@ -234,7 +234,8 @@ func compactTelegramGroupEnvelopeBurstOrderedParts(tail []llm.Message) ([]llm.Co
 		return nil, false
 	}
 
-	header := fmt.Sprintf("Telegram %s", conversationType)
+	channelLabel := strings.ToUpper(channel[:1]) + channel[1:]
+	header := fmt.Sprintf("%s %s", channelLabel, conversationType)
 	if title := commonEnvelopeValue(toTelegramEnvelopeMessages(items), "conversation-title"); title != "" {
 		header += fmt.Sprintf(" %q", title)
 	}


### PR DESCRIPTION
## Summary

- QQ private messages with images fell through to `formatNaturalPrefix`, which rendered message-id as `Alice (#42):` — the LLM misread `#42` as a QQ号 instead of a message reference (#59)
- Remove `channel=="telegram"` hard filter in ordered-parts compaction path so QQ image messages get the same timeline format as Telegram
- Build header from dynamic `channelLabel` instead of hardcoded `"Telegram"` (QQ now produces `Qq private`/`Qq group`)
- Change `formatNaturalPrefix` from `Alice (#42):` to `[#42] Alice:`, separating message-id from display-name to match compact path
- Extend admin-tag middleware to QQ/qqbot channels

## Test plan

- [x] `go test ./internal/pipeline/...` passes
- [ ] Verify QQ text-only private messages still render as `Qq private\n[10:30:05 #42] Alice: hello`
- [ ] Verify QQ image private messages now render with timeline format (previously raw YAML)
- [ ] Verify Telegram messages unchanged

Closes #59