### PR TITLE
fix(channels): sync owner bindings

### DIFF
--- a/src/apps/web/src/components/settings/DesktopChannelSettingsShared.tsx
+++ b/src/apps/web/src/components/settings/DesktopChannelSettingsShared.tsx
@@ -262,7 +262,6 @@ function BindingHeartbeatEditor({
   cancelLabel,
   onMakeOwner,
   onUnbind,
-  onOwnerUnbindAttempt,
 }: {
   binding: ChannelBindingResponse
   modelOptions: ModelOption[]
@@ -280,7 +279,6 @@ function BindingHeartbeatEditor({
   onSaveHeartbeat: (binding: ChannelBindingResponse, next: { enabled: boolean; interval: number; model: string }) => Promise<void>
   onMakeOwner: (binding: ChannelBindingResponse) => Promise<void>
   onUnbind: (binding: ChannelBindingResponse) => Promise<void>
-  onOwnerUnbindAttempt: () => void
 }) {
   const [promotingOwner, setPromotingOwner] = useState(false)
   const [confirmUnbind, setConfirmUnbind] = useState(false)
@@ -337,13 +335,7 @@ function BindingHeartbeatEditor({
             <button
               type="button"
               aria-label={`${unbindLabel} ${binding.display_name || binding.platform_subject_id}`}
-              onClick={() => {
-                if (binding.is_owner) {
-                  onOwnerUnbindAttempt()
-                  return
-                }
-                setConfirmUnbind(true)
-              }}
+              onClick={() => setConfirmUnbind(true)}
               className="rounded-md px-2.5 py-1 text-xs font-medium text-[var(--c-text-secondary)] transition-colors hover:bg-[var(--c-bg-deep)]"
             >
               {unbindLabel}
@@ -387,7 +379,6 @@ export function BindingsCard({
   onUnbind,
   onMakeOwner,
   onSaveHeartbeat,
-  onOwnerUnbindAttempt,
 }: {
   title: string
   bindings: ChannelBindingResponse[]
@@ -410,7 +401,6 @@ export function BindingsCard({
   onUnbind: (binding: ChannelBindingResponse) => Promise<void>
   onMakeOwner: (binding: ChannelBindingResponse) => Promise<void>
   onSaveHeartbeat: (binding: ChannelBindingResponse, next: { enabled: boolean; interval: number; model: string }) => Promise<void>
-  onOwnerUnbindAttempt: () => void
 }) {
   const { t } = useLocale()
   return (
@@ -467,7 +457,6 @@ export function BindingsCard({
                 onSaveHeartbeat={onSaveHeartbeat}
                 onMakeOwner={onMakeOwner}
                 onUnbind={onUnbind}
-                onOwnerUnbindAttempt={onOwnerUnbindAttempt}
               />
             ))}
           </div>

--- a/src/apps/web/src/components/settings/DesktopDiscordSettingsPanel.tsx
+++ b/src/apps/web/src/components/settings/DesktopDiscordSettingsPanel.tsx
@@ -422,7 +422,6 @@ export function DesktopDiscordSettingsPanel({
         onUnbind={(binding) => handleUnbind(binding)}
         onMakeOwner={(binding) => handleMakeOwner(binding)}
         onSaveHeartbeat={(binding, next) => handleSaveHeartbeat(binding, next)}
-        onOwnerUnbindAttempt={() => setError(ct.ownerUnbindBlocked)}
       />
 
       <SaveActions

--- a/src/apps/web/src/components/settings/DesktopQQBotSettingsPanel.tsx
+++ b/src/apps/web/src/components/settings/DesktopQQBotSettingsPanel.tsx
@@ -416,7 +416,6 @@ export function DesktopQQBotSettingsPanel({
         onUnbind={(binding) => handleUnbind(binding)}
         onMakeOwner={(binding) => handleMakeOwner(binding)}
         onSaveHeartbeat={(binding, next) => handleSaveHeartbeat(binding, next)}
-        onOwnerUnbindAttempt={() => setError(ct.ownerUnbindBlocked)}
       />
 
       <SaveActions

--- a/src/apps/web/src/components/settings/DesktopQQSettingsPanel.tsx
+++ b/src/apps/web/src/components/settings/DesktopQQSettingsPanel.tsx
@@ -466,7 +466,6 @@ export function DesktopQQSettingsPanel({
         onUnbind={(binding) => handleUnbind(binding)}
         onMakeOwner={(binding) => handleMakeOwner(binding)}
         onSaveHeartbeat={(binding, next) => handleSaveHeartbeat(binding, next)}
-        onOwnerUnbindAttempt={() => setError(ct.ownerUnbindBlocked)}
       />
 
       <SaveActions

--- a/src/apps/web/src/components/settings/DesktopTelegramSettingsPanel.tsx
+++ b/src/apps/web/src/components/settings/DesktopTelegramSettingsPanel.tsx
@@ -495,7 +495,6 @@ export function DesktopTelegramSettingsPanel({
         onUnbind={(binding) => handleUnbind(binding)}
         onMakeOwner={(binding) => handleMakeOwner(binding)}
         onSaveHeartbeat={(binding, next) => handleSaveHeartbeat(binding, next)}
-        onOwnerUnbindAttempt={() => setError(ct.ownerUnbindBlocked)}
       />
 
       <SaveActions

--- a/src/apps/web/src/components/settings/DesktopWeixinSettingsPanel.tsx
+++ b/src/apps/web/src/components/settings/DesktopWeixinSettingsPanel.tsx
@@ -611,7 +611,6 @@ export function DesktopWeixinSettingsPanel({
         onUnbind={(binding) => handleUnbind(binding)}
         onMakeOwner={(binding) => handleMakeOwner(binding)}
         onSaveHeartbeat={(binding, next) => handleSaveHeartbeat(binding, next)}
-        onOwnerUnbindAttempt={() => setError(ct.ownerUnbindBlocked)}
       />
 
       <SaveActions

--- a/src/apps/web/src/locales/en.ts
+++ b/src/apps/web/src/locales/en.ts
@@ -840,7 +840,6 @@ export const en: LocaleStrings = {
     heartbeatCardTitle: 'Heartbeat',
     heartbeatCardDesc: 'After linking an account, send /heartbeat on in the conversation to enable it. The bot will then wake up at the configured interval and decide on its own whether to send a message',
     heartbeatCardHint: 'Send /heartbeat off in the conversation to disable it at any time',
-    ownerUnbindBlocked: 'Owner cannot be unlinked directly',
     botTokenHint: 'Get your token from @BotFather on Telegram',
     allowedUsersHint: 'Get your user ID from @userinfobot (send /start)',
     discordTokenHint: 'Create a bot at Discord Developer Portal',

--- a/src/apps/web/src/locales/index.ts
+++ b/src/apps/web/src/locales/index.ts
@@ -770,7 +770,6 @@ export interface LocaleStrings {
     heartbeatCardTitle: string
     heartbeatCardDesc: string
     heartbeatCardHint: string
-    ownerUnbindBlocked: string
     botTokenHint: string
     allowedUsersHint: string
     discordTokenHint: string

--- a/src/apps/web/src/locales/zh.ts
+++ b/src/apps/web/src/locales/zh.ts
@@ -834,7 +834,6 @@ export const zh: LocaleStrings = {
     heartbeatCardTitle: 'Heartbeat',
     heartbeatCardDesc: '让 bot 在绑定的对话中定时自动唤醒，由 AI 自主判断是否主动发言。绑定账号后，在对话中发 /heartbeat on 开启，/heartbeat off 关闭，/heartbeat interval <分钟> 调整频率',
     heartbeatCardHint: '间隔和模型可在下方关联账号的卡片中精细配置',
-    ownerUnbindBlocked: 'Owner 不能直接解除关联',
     botTokenHint: '从 Telegram 的 @BotFather 获取 Token',
     allowedUsersHint: '向 @userinfobot 发送 /start 即可获取 user ID',
     discordTokenHint: '在 Discord Developer Portal 创建 bot 并获取 Token',

--- a/src/services/api/internal/data/channel_identity_links_repo.go
+++ b/src/services/api/internal/data/channel_identity_links_repo.go
@@ -21,6 +21,7 @@ type ChannelIdentityLink struct {
 type ChannelBinding struct {
 	BindingID         uuid.UUID
 	ChannelID         uuid.UUID
+	AccountID         uuid.UUID
 	ChannelIdentityID uuid.UUID
 	UserID            *uuid.UUID
 	DisplayName       *string
@@ -93,6 +94,7 @@ func (r *ChannelIdentityLinksRepository) GetBinding(
 		ctx,
 		`SELECT cil.id,
 		        cil.channel_id,
+		        ch.account_id,
 		        ci.id,
 		        ci.user_id,
 		        ci.display_name,
@@ -131,6 +133,7 @@ func (r *ChannelIdentityLinksRepository) ListBindings(
 		ctx,
 		`SELECT cil.id,
 		        cil.channel_id,
+		        ch.account_id,
 		        ci.id,
 		        ci.user_id,
 		        ci.display_name,
@@ -174,6 +177,7 @@ func (r *ChannelIdentityLinksRepository) ListBindingsByIdentity(
 		ctx,
 		`SELECT cil.id,
 		        cil.channel_id,
+		        ch.account_id,
 		        ci.id,
 		        ci.user_id,
 		        ci.display_name,
@@ -279,6 +283,7 @@ func scanChannelBinding(row interface{ Scan(dest ...any) error }) (ChannelBindin
 	err := row.Scan(
 		&item.BindingID,
 		&item.ChannelID,
+		&item.AccountID,
 		&item.ChannelIdentityID,
 		&item.UserID,
 		&item.DisplayName,

--- a/src/services/api/internal/data/channels_repo.go
+++ b/src/services/api/internal/data/channels_repo.go
@@ -221,6 +221,66 @@ func (r *ChannelsRepository) Update(ctx context.Context, id uuid.UUID, accountID
 	return &ch, nil
 }
 
+func (r *ChannelsRepository) SetOwnerIfMissing(ctx context.Context, id uuid.UUID, accountID uuid.UUID, ownerUserID uuid.UUID) (*Channel, error) {
+	if id == uuid.Nil || accountID == uuid.Nil {
+		return nil, fmt.Errorf("channels.SetOwnerIfMissing: channel id and account id must not be empty")
+	}
+	if ownerUserID == uuid.Nil {
+		return nil, fmt.Errorf("channels.SetOwnerIfMissing: owner_user_id must not be empty")
+	}
+
+	ch, err := scanChannel(r.db.QueryRow(ctx,
+		`UPDATE channels
+		    SET owner_user_id = $3,
+		        updated_at = now()
+		  WHERE id = $1
+		    AND account_id = $2
+		    AND owner_user_id IS NULL
+		    AND EXISTS (
+		      SELECT 1
+		        FROM account_memberships
+		       WHERE account_id = $2
+		         AND user_id = $3
+		    )
+		  RETURNING `+channelColumns,
+		id, accountID, ownerUserID,
+	))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("channels.SetOwnerIfMissing: %w", err)
+	}
+	return &ch, nil
+}
+
+func (r *ChannelsRepository) ClearOwnerIfMatches(ctx context.Context, id uuid.UUID, accountID uuid.UUID, ownerUserID uuid.UUID) (*Channel, error) {
+	if id == uuid.Nil || accountID == uuid.Nil {
+		return nil, fmt.Errorf("channels.ClearOwnerIfMatches: channel id and account id must not be empty")
+	}
+	if ownerUserID == uuid.Nil {
+		return nil, fmt.Errorf("channels.ClearOwnerIfMatches: owner_user_id must not be empty")
+	}
+
+	ch, err := scanChannel(r.db.QueryRow(ctx,
+		`UPDATE channels
+		    SET owner_user_id = NULL,
+		        updated_at = now()
+		  WHERE id = $1
+		    AND account_id = $2
+		    AND owner_user_id = $3
+		  RETURNING `+channelColumns,
+		id, accountID, ownerUserID,
+	))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("channels.ClearOwnerIfMatches: %w", err)
+	}
+	return &ch, nil
+}
+
 func (r *ChannelsRepository) Delete(ctx context.Context, id uuid.UUID, accountID uuid.UUID) error {
 	tag, err := r.db.Exec(ctx,
 		`DELETE FROM channels WHERE id = $1 AND account_id = $2`,

--- a/src/services/api/internal/data/channels_repo_integration_test.go
+++ b/src/services/api/internal/data/channels_repo_integration_test.go
@@ -1,0 +1,178 @@
+//go:build !desktop
+
+package data
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"arkloop/services/api/internal/migrate"
+	"arkloop/services/api/internal/testutil"
+
+	"github.com/google/uuid"
+)
+
+type channelsRepoOwnerTestEnv struct {
+	ctx        context.Context
+	repo       *ChannelsRepository
+	accountID  uuid.UUID
+	ownerID    uuid.UUID
+	nextID     uuid.UUID
+	outsiderID uuid.UUID
+}
+
+func setupChannelsRepoOwnerTestEnv(t *testing.T) channelsRepoOwnerTestEnv {
+	t.Helper()
+
+	ctx := context.Background()
+	db := testutil.SetupPostgresDatabase(t, "api_go_channels_repo_owner")
+	if _, err := migrate.Up(ctx, db.DSN); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+	pool, err := NewPool(ctx, db.DSN, PoolLimits{MaxConns: 8, MinConns: 0})
+	if err != nil {
+		t.Fatalf("new pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	repo, err := NewChannelsRepository(pool)
+	if err != nil {
+		t.Fatalf("new channels repo: %v", err)
+	}
+	accountRepo, err := NewAccountRepository(pool)
+	if err != nil {
+		t.Fatalf("new account repo: %v", err)
+	}
+	userRepo, err := NewUserRepository(pool)
+	if err != nil {
+		t.Fatalf("new user repo: %v", err)
+	}
+	membershipRepo, err := NewAccountMembershipRepository(pool)
+	if err != nil {
+		t.Fatalf("new membership repo: %v", err)
+	}
+	account, err := accountRepo.Create(ctx, "channels-owner", "Channels Owner", "personal")
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	owner, err := userRepo.Create(ctx, "channels-owner-1", "channels-owner-1@test.com", "zh")
+	if err != nil {
+		t.Fatalf("create owner user: %v", err)
+	}
+	next, err := userRepo.Create(ctx, "channels-owner-2", "channels-owner-2@test.com", "zh")
+	if err != nil {
+		t.Fatalf("create next user: %v", err)
+	}
+	outsider, err := userRepo.Create(ctx, "channels-owner-outsider", "channels-owner-outsider@test.com", "zh")
+	if err != nil {
+		t.Fatalf("create outsider user: %v", err)
+	}
+	if _, err := membershipRepo.Create(ctx, account.ID, owner.ID, "account_admin"); err != nil {
+		t.Fatalf("create owner membership: %v", err)
+	}
+	if _, err := membershipRepo.Create(ctx, account.ID, next.ID, "account_admin"); err != nil {
+		t.Fatalf("create next membership: %v", err)
+	}
+	return channelsRepoOwnerTestEnv{
+		ctx:        ctx,
+		repo:       repo,
+		accountID:  account.ID,
+		ownerID:    owner.ID,
+		nextID:     next.ID,
+		outsiderID: outsider.ID,
+	}
+}
+
+func (e channelsRepoOwnerTestEnv) createChannel(t *testing.T, ownerUserID *uuid.UUID) Channel {
+	t.Helper()
+	channel, err := e.repo.Create(e.ctx, uuid.New(), e.accountID, "discord", nil, nil, ownerUserID, "", "", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("create channel: %v", err)
+	}
+	return channel
+}
+
+func TestChannelsRepositorySetOwnerIfMissingDoesNotOverwriteExistingOwner(t *testing.T) {
+	env := setupChannelsRepoOwnerTestEnv(t)
+	channel := env.createChannel(t, nil)
+
+	updated, err := env.repo.SetOwnerIfMissing(env.ctx, channel.ID, env.accountID, env.ownerID)
+	if err != nil {
+		t.Fatalf("set missing owner: %v", err)
+	}
+	if updated == nil || updated.OwnerUserID == nil || *updated.OwnerUserID != env.ownerID {
+		t.Fatalf("unexpected owner after first set: %#v", updated)
+	}
+
+	updated, err = env.repo.SetOwnerIfMissing(env.ctx, channel.ID, env.accountID, env.nextID)
+	if err != nil {
+		t.Fatalf("set existing owner: %v", err)
+	}
+	if updated != nil {
+		t.Fatalf("expected existing owner update to no-op, got %#v", updated)
+	}
+
+	got, err := env.repo.GetByID(env.ctx, channel.ID)
+	if err != nil {
+		t.Fatalf("get channel: %v", err)
+	}
+	if got == nil || got.OwnerUserID == nil || *got.OwnerUserID != env.ownerID {
+		t.Fatalf("owner was overwritten: %#v", got)
+	}
+}
+
+func TestChannelsRepositorySetOwnerIfMissingRejectsNonMember(t *testing.T) {
+	env := setupChannelsRepoOwnerTestEnv(t)
+	channel := env.createChannel(t, nil)
+
+	updated, err := env.repo.SetOwnerIfMissing(env.ctx, channel.ID, env.accountID, env.outsiderID)
+	if err != nil {
+		t.Fatalf("set outsider owner: %v", err)
+	}
+	if updated != nil {
+		t.Fatalf("expected outsider owner update to no-op, got %#v", updated)
+	}
+
+	got, err := env.repo.GetByID(env.ctx, channel.ID)
+	if err != nil {
+		t.Fatalf("get channel: %v", err)
+	}
+	if got == nil || got.OwnerUserID != nil {
+		t.Fatalf("outsider became owner: %#v", got)
+	}
+}
+
+func TestChannelsRepositoryClearOwnerIfMatchesDoesNotClearTransferredOwner(t *testing.T) {
+	env := setupChannelsRepoOwnerTestEnv(t)
+	channel := env.createChannel(t, &env.ownerID)
+
+	nextOwner := &env.nextID
+	if _, err := env.repo.Update(env.ctx, channel.ID, env.accountID, ChannelUpdate{OwnerUserID: &nextOwner}); err != nil {
+		t.Fatalf("transfer owner: %v", err)
+	}
+
+	updated, err := env.repo.ClearOwnerIfMatches(env.ctx, channel.ID, env.accountID, env.ownerID)
+	if err != nil {
+		t.Fatalf("clear stale owner: %v", err)
+	}
+	if updated != nil {
+		t.Fatalf("expected stale owner clear to no-op, got %#v", updated)
+	}
+
+	got, err := env.repo.GetByID(env.ctx, channel.ID)
+	if err != nil {
+		t.Fatalf("get channel after stale clear: %v", err)
+	}
+	if got == nil || got.OwnerUserID == nil || *got.OwnerUserID != env.nextID {
+		t.Fatalf("stale clear changed owner: %#v", got)
+	}
+
+	updated, err = env.repo.ClearOwnerIfMatches(env.ctx, channel.ID, env.accountID, env.nextID)
+	if err != nil {
+		t.Fatalf("clear current owner: %v", err)
+	}
+	if updated == nil || updated.OwnerUserID != nil {
+		t.Fatalf("expected current owner to be cleared, got %#v", updated)
+	}
+}

--- a/src/services/api/internal/http/accountapi/channel_bindings_integration_test.go
+++ b/src/services/api/internal/http/accountapi/channel_bindings_integration_test.go
@@ -12,6 +12,8 @@ import (
 	"arkloop/services/api/internal/auth"
 	"arkloop/services/api/internal/data"
 	"arkloop/services/shared/discordbot"
+
+	"github.com/google/uuid"
 )
 
 func TestChannelBindingsEndpointsSupportOwnerTransferAndHeartbeat(t *testing.T) {
@@ -39,6 +41,13 @@ func TestChannelBindingsEndpointsSupportOwnerTransferAndHeartbeat(t *testing.T) 
 	secondUser, err := userRepo.Create(context.Background(), "discord-admin", "discord-admin@test.com", "zh")
 	if err != nil {
 		t.Fatalf("create second user: %v", err)
+	}
+	membershipRepo, err := data.NewAccountMembershipRepository(env.pool)
+	if err != nil {
+		t.Fatalf("membership repo: %v", err)
+	}
+	if _, err := membershipRepo.Create(context.Background(), env.accountID, secondUser.ID, auth.RoleAccountAdmin); err != nil {
+		t.Fatalf("create second membership: %v", err)
 	}
 	adminCode, err := env.channelBindCodesRepo.Create(context.Background(), secondUser.ID, stringPtr("discord"), time.Hour)
 	if err != nil {
@@ -116,11 +125,29 @@ func TestChannelBindingsEndpointsSupportOwnerTransferAndHeartbeat(t *testing.T) 
 	if !adminBinding.IsOwner {
 		t.Fatalf("expected admin to become owner: %#v", adminBinding)
 	}
+
+	deleteResp := doJSONAccount(
+		env.handler,
+		nethttp.MethodDelete,
+		"/v1/channels/"+channel.ID.String()+"/bindings/"+ownerBinding.BindingID,
+		nil,
+		authHeader(env.accessToken),
+	)
+	if deleteResp.Code != nethttp.StatusOK {
+		t.Fatalf("delete non-owner binding: %d %s", deleteResp.Code, deleteResp.Body.String())
+	}
+	updatedChannel, err := env.channelsRepo.GetByID(context.Background(), channel.ID)
+	if err != nil {
+		t.Fatalf("get channel after non-owner delete: %v", err)
+	}
+	if updatedChannel == nil || updatedChannel.OwnerUserID == nil || *updatedChannel.OwnerUserID != secondUser.ID {
+		t.Fatalf("non-owner delete changed owner: %#v", updatedChannel)
+	}
 }
 
-func TestChannelBindingsOwnerDeleteBlocked(t *testing.T) {
+func TestChannelBindingsOwnerDeleteAllowed(t *testing.T) {
 	env := setupDiscordChannelsTestEnv(t, discordbot.NewClient("", nil))
-	channel := createActiveDiscordChannelWithConfig(t, env, "discord-owner-block-token", map[string]any{})
+	channel := createActiveDiscordChannelWithConfig(t, env, "discord-owner-delete-token", map[string]any{})
 
 	code, err := env.channelBindCodesRepo.Create(context.Background(), env.userID, stringPtr("discord"), time.Hour)
 	if err != nil {
@@ -128,10 +155,10 @@ func TestChannelBindingsOwnerDeleteBlocked(t *testing.T) {
 	}
 	if _, err := env.connector().HandleInteraction(
 		context.Background(),
-		"trace-owner-block",
+		"trace-owner-delete",
 		channel.ID,
-		"discord-owner-block-token",
-		newDiscordInteractionCommand("bind", "", "dm-owner-block", "u-owner-block", "owner-block", code.Token),
+		"discord-owner-delete-token",
+		newDiscordInteractionCommand("bind", "", "dm-owner-delete", "u-owner-delete", "owner-delete", code.Token),
 	); err != nil {
 		t.Fatalf("bind interaction: %v", err)
 	}
@@ -155,8 +182,133 @@ func TestChannelBindingsOwnerDeleteBlocked(t *testing.T) {
 		nil,
 		authHeader(env.accessToken),
 	)
-	if deleteResp.Code != nethttp.StatusConflict {
+	if deleteResp.Code != nethttp.StatusOK {
 		t.Fatalf("delete owner binding: %d %s", deleteResp.Code, deleteResp.Body.String())
+	}
+
+	listResp = doJSONAccount(env.handler, nethttp.MethodGet, "/v1/channels/"+channel.ID.String()+"/bindings", nil, authHeader(env.accessToken))
+	if listResp.Code != nethttp.StatusOK {
+		t.Fatalf("list bindings after delete: %d %s", listResp.Code, listResp.Body.String())
+	}
+	listBody = nil
+	if err := json.Unmarshal(listResp.Body.Bytes(), &listBody); err != nil {
+		t.Fatalf("decode bindings response after delete: %v", err)
+	}
+	if len(listBody) != 0 {
+		t.Fatalf("expected 0 bindings after delete, got %d", len(listBody))
+	}
+
+	updatedChannel, err := env.channelsRepo.GetByID(context.Background(), channel.ID)
+	if err != nil {
+		t.Fatalf("get channel after owner delete: %v", err)
+	}
+	if updatedChannel == nil || updatedChannel.OwnerUserID != nil {
+		t.Fatalf("expected channel owner to be cleared, got %#v", updatedChannel)
+	}
+
+	nextCode, err := env.channelBindCodesRepo.Create(context.Background(), env.userID, stringPtr("discord"), time.Hour)
+	if err != nil {
+		t.Fatalf("create rebind code: %v", err)
+	}
+	if _, err := env.connector().HandleInteraction(
+		context.Background(),
+		"trace-owner-rebind",
+		channel.ID,
+		"discord-owner-delete-token",
+		newDiscordInteractionCommand("bind", "", "dm-owner-delete", "u-owner-delete", "owner-delete", nextCode.Token),
+	); err != nil {
+		t.Fatalf("rebind interaction: %v", err)
+	}
+	updatedChannel, err = env.channelsRepo.GetByID(context.Background(), channel.ID)
+	if err != nil {
+		t.Fatalf("get channel after rebind: %v", err)
+	}
+	if updatedChannel == nil || updatedChannel.OwnerUserID == nil || *updatedChannel.OwnerUserID != env.userID {
+		t.Fatalf("expected rebind to restore owner, got %#v", updatedChannel)
+	}
+	listResp = doJSONAccount(env.handler, nethttp.MethodGet, "/v1/channels/"+channel.ID.String()+"/bindings", nil, authHeader(env.accessToken))
+	if listResp.Code != nethttp.StatusOK {
+		t.Fatalf("list bindings after rebind: %d %s", listResp.Code, listResp.Body.String())
+	}
+	listBody = nil
+	if err := json.Unmarshal(listResp.Body.Bytes(), &listBody); err != nil {
+		t.Fatalf("decode bindings response after rebind: %v", err)
+	}
+	if len(listBody) != 1 || !listBody[0].IsOwner {
+		t.Fatalf("expected owner binding after rebind, got %#v", listBody)
+	}
+}
+
+func TestChannelIdentityUnbindClearsOwnedChannels(t *testing.T) {
+	env := setupDiscordChannelsTestEnv(t, discordbot.NewClient("", nil))
+	channel := createActiveDiscordChannelWithConfig(t, env, "discord-owner-unbind-token", map[string]any{})
+
+	code, err := env.channelBindCodesRepo.Create(context.Background(), env.userID, stringPtr("discord"), time.Hour)
+	if err != nil {
+		t.Fatalf("create bind code: %v", err)
+	}
+	if _, err := env.connector().HandleInteraction(
+		context.Background(),
+		"trace-owner-unbind",
+		channel.ID,
+		"discord-owner-unbind-token",
+		newDiscordInteractionCommand("bind", "", "dm-owner-unbind", "u-owner-unbind", "owner-unbind", code.Token),
+	); err != nil {
+		t.Fatalf("bind interaction: %v", err)
+	}
+
+	listResp := doJSONAccount(env.handler, nethttp.MethodGet, "/v1/channels/"+channel.ID.String()+"/bindings", nil, authHeader(env.accessToken))
+	if listResp.Code != nethttp.StatusOK {
+		t.Fatalf("list bindings: %d %s", listResp.Code, listResp.Body.String())
+	}
+	var listBody []channelBindingResponse
+	if err := json.Unmarshal(listResp.Body.Bytes(), &listBody); err != nil {
+		t.Fatalf("decode bindings response: %v", err)
+	}
+	if len(listBody) != 1 || !listBody[0].IsOwner {
+		t.Fatalf("expected owner binding, got %#v", listBody)
+	}
+
+	unbindResp := doJSONAccount(
+		env.handler,
+		nethttp.MethodDelete,
+		"/v1/me/channel-identities/"+listBody[0].ChannelIdentityID,
+		nil,
+		authHeader(env.accessToken),
+	)
+	if unbindResp.Code != nethttp.StatusOK {
+		t.Fatalf("unbind identity: %d %s", unbindResp.Code, unbindResp.Body.String())
+	}
+
+	updatedChannel, err := env.channelsRepo.GetByID(context.Background(), channel.ID)
+	if err != nil {
+		t.Fatalf("get channel after identity unbind: %v", err)
+	}
+	if updatedChannel == nil || updatedChannel.OwnerUserID != nil {
+		t.Fatalf("expected channel owner to be cleared, got %#v", updatedChannel)
+	}
+	identityID := listBody[0].ChannelIdentityID
+	parsedIdentityID, err := uuid.Parse(identityID)
+	if err != nil {
+		t.Fatalf("parse identity id: %v", err)
+	}
+	identity, err := env.channelIdentitiesRepo.GetByID(context.Background(), parsedIdentityID)
+	if err != nil {
+		t.Fatalf("get identity after unbind: %v", err)
+	}
+	if identity == nil || identity.UserID != nil {
+		t.Fatalf("expected identity user to be cleared, got %#v", identity)
+	}
+	listResp = doJSONAccount(env.handler, nethttp.MethodGet, "/v1/channels/"+channel.ID.String()+"/bindings", nil, authHeader(env.accessToken))
+	if listResp.Code != nethttp.StatusOK {
+		t.Fatalf("list bindings after identity unbind: %d %s", listResp.Code, listResp.Body.String())
+	}
+	listBody = nil
+	if err := json.Unmarshal(listResp.Body.Bytes(), &listBody); err != nil {
+		t.Fatalf("decode bindings response after identity unbind: %v", err)
+	}
+	if len(listBody) != 0 {
+		t.Fatalf("expected no bindings after identity unbind, got %#v", listBody)
 	}
 }
 

--- a/src/services/api/internal/http/accountapi/channels_command_dispatch.go
+++ b/src/services/api/internal/http/accountapi/channels_command_dispatch.go
@@ -15,6 +15,7 @@ import (
 
 // ChannelCommandDeps groups repository dependencies for DispatchChannelCommand.
 type ChannelCommandDeps struct {
+	ChannelsRepo             *data.ChannelsRepository
 	ChannelIdentitiesRepo    *data.ChannelIdentitiesRepository
 	ChannelDMThreadsRepo     *data.ChannelDMThreadsRepository
 	ChannelGroupThreadsRepo  *data.ChannelGroupThreadsRepository
@@ -223,7 +224,7 @@ func DispatchChannelCommand(
 			payload := resolver.ResolveStartPayload()
 			if strings.HasPrefix(payload, "bind_") {
 				code := strings.TrimPrefix(payload, "bind_")
-				replyText, err := bindChannelIdentity(ctx, tx, &ch, identity, code, channelLabel, deps.ChannelBindCodesRepo, deps.ChannelIdentitiesRepo, deps.ChannelIdentityLinksRepo, deps.ChannelDMThreadsRepo, deps.ThreadRepo)
+				replyText, err := bindChannelIdentity(ctx, tx, &ch, identity, code, channelLabel, deps.ChannelBindCodesRepo, deps.ChannelIdentitiesRepo, deps.ChannelIdentityLinksRepo, deps.ChannelDMThreadsRepo, deps.ThreadRepo, deps.ChannelsRepo)
 				return true, replyText, nil, nil, uuid.Nil, err
 			}
 		}
@@ -237,7 +238,7 @@ func DispatchChannelCommand(
 		if code == "" {
 			return true, "用法：/bind <code>", nil, nil, uuid.Nil, nil
 		}
-		replyText, err := bindChannelIdentity(ctx, tx, &ch, identity, code, channelLabel, deps.ChannelBindCodesRepo, deps.ChannelIdentitiesRepo, deps.ChannelIdentityLinksRepo, deps.ChannelDMThreadsRepo, deps.ThreadRepo)
+		replyText, err := bindChannelIdentity(ctx, tx, &ch, identity, code, channelLabel, deps.ChannelBindCodesRepo, deps.ChannelIdentitiesRepo, deps.ChannelIdentityLinksRepo, deps.ChannelDMThreadsRepo, deps.ThreadRepo, deps.ChannelsRepo)
 		return true, replyText, nil, nil, uuid.Nil, err
 
 	case cmd == "/reset":

--- a/src/services/api/internal/http/accountapi/channels_discord_ingress.go
+++ b/src/services/api/internal/http/accountapi/channels_discord_ingress.go
@@ -470,7 +470,7 @@ func (c discordConnector) HandleInteraction(
 		return nil, err
 	}
 
-	reply, err := handleDiscordCommand(ctx, tx, ch, identity, event, c.channelBindCodesRepo, c.channelIdentitiesRepo, c.channelIdentityLinksRepo, c.channelDMThreadsRepo, c.threadRepo, c.runEventRepo, c.pool)
+	reply, err := handleDiscordCommand(ctx, tx, ch, identity, event, c.channelBindCodesRepo, c.channelIdentitiesRepo, c.channelIdentityLinksRepo, c.channelDMThreadsRepo, c.threadRepo, c.runEventRepo, c.channelsRepo, c.pool)
 	if err != nil {
 		return nil, err
 	}
@@ -986,6 +986,7 @@ func handleDiscordCommand(
 	channelDMThreadsRepo *data.ChannelDMThreadsRepository,
 	threadRepo *data.ThreadRepository,
 	runEventRepo *data.RunEventRepository,
+	channelsRepo *data.ChannelsRepository,
 	pool data.DB,
 ) (*discordInteractionReply, error) {
 	data := evt.ApplicationCommandData()
@@ -1007,7 +1008,7 @@ func handleDiscordCommand(
 		if len(data.Options) > 0 {
 			code = strings.TrimSpace(data.Options[0].StringValue())
 		}
-		replyText, err := bindDiscordIdentity(ctx, tx, channel, identity, code, channelBindCodesRepo, channelIdentitiesRepo, channelIdentityLinksRepo, channelDMThreadsRepo, threadRepo)
+		replyText, err := bindDiscordIdentity(ctx, tx, channel, identity, code, channelBindCodesRepo, channelIdentitiesRepo, channelIdentityLinksRepo, channelDMThreadsRepo, threadRepo, channelsRepo)
 		if err != nil {
 			return nil, err
 		}
@@ -1170,6 +1171,7 @@ func bindDiscordIdentity(
 	channelIdentityLinksRepo *data.ChannelIdentityLinksRepository,
 	channelDMThreadsRepo *data.ChannelDMThreadsRepository,
 	threadRepo *data.ThreadRepository,
+	channelsRepo *data.ChannelsRepository,
 ) (string, error) {
 	code = strings.ToUpper(strings.TrimSpace(code))
 	if code == "" {
@@ -1194,6 +1196,9 @@ func bindDiscordIdentity(
 				return "", err
 			}
 		}
+		if err := setChannelOwnerIfMissing(ctx, tx, channel, activeCode.IssuedByUserID, channelsRepo); err != nil {
+			return "", err
+		}
 		return "账号已绑定。", nil
 	}
 
@@ -1211,6 +1216,9 @@ func bindDiscordIdentity(
 		if _, err := channelIdentityLinksRepo.WithTx(tx).Upsert(ctx, channel.ID, identity.ID); err != nil {
 			return "", err
 		}
+	}
+	if err := setChannelOwnerIfMissing(ctx, tx, channel, consumed.IssuedByUserID, channelsRepo); err != nil {
+		return "", err
 	}
 	threadMappings, err := channelDMThreadsRepo.WithTx(tx).ListByChannelIdentity(ctx, channel.ID, identity.ID)
 	if err != nil {

--- a/src/services/api/internal/http/accountapi/channels_feishu.go
+++ b/src/services/api/internal/http/accountapi/channels_feishu.go
@@ -964,6 +964,7 @@ func (c *feishuConnector) HandleIncoming(ctx context.Context, traceID string, ch
 			},
 		},
 		ChannelCommandDeps{
+			ChannelsRepo:             c.channelsRepo,
 			ChannelIdentitiesRepo:    c.channelIdentitiesRepo,
 			ChannelDMThreadsRepo:     c.channelDMThreadsRepo,
 			ChannelGroupThreadsRepo:  c.channelGroupThreadsRepo,

--- a/src/services/api/internal/http/accountapi/channels_qq.go
+++ b/src/services/api/internal/http/accountapi/channels_qq.go
@@ -372,6 +372,7 @@ func (c *qqConnector) HandleEvent(ctx context.Context, traceID string, ch data.C
 				},
 			},
 			ChannelCommandDeps{
+				ChannelsRepo:             c.channelsRepo,
 				ChannelIdentitiesRepo:    c.channelIdentitiesRepo,
 				ChannelDMThreadsRepo:     c.channelDMThreadsRepo,
 				ChannelGroupThreadsRepo:  c.channelGroupThreadsRepo,
@@ -430,6 +431,7 @@ func (c *qqConnector) HandleEvent(ctx context.Context, traceID string, ch data.C
 				},
 			},
 			ChannelCommandDeps{
+				ChannelsRepo:             c.channelsRepo,
 				ChannelIdentitiesRepo:    c.channelIdentitiesRepo,
 				ChannelDMThreadsRepo:     c.channelDMThreadsRepo,
 				ChannelGroupThreadsRepo:  c.channelGroupThreadsRepo,

--- a/src/services/api/internal/http/accountapi/channels_qqbot.go
+++ b/src/services/api/internal/http/accountapi/channels_qqbot.go
@@ -150,6 +150,7 @@ type qqbotIngressManager struct {
 }
 
 type qqbotConnector struct {
+	channelsRepo             *data.ChannelsRepository
 	channelIdentitiesRepo    *data.ChannelIdentitiesRepository
 	channelBindCodesRepo     *data.ChannelBindCodesRepository
 	channelIdentityLinksRepo *data.ChannelIdentityLinksRepository
@@ -265,6 +266,7 @@ func (m *qqbotIngressManager) ensureSession(parent context.Context, ch data.Chan
 		defer close(done)
 		client := qqbotclient.NewClient(creds, nil)
 		connector := qqbotConnector{
+			channelsRepo:             m.deps.ChannelsRepo,
 			channelIdentitiesRepo:    m.deps.ChannelIdentitiesRepo,
 			channelBindCodesRepo:     m.deps.ChannelBindCodesRepo,
 			channelIdentityLinksRepo: m.deps.ChannelIdentityLinksRepo,
@@ -432,6 +434,7 @@ func (c qqbotConnector) HandleMessage(ctx context.Context, traceID string, ch da
 			},
 		},
 		ChannelCommandDeps{
+			ChannelsRepo:             c.channelsRepo,
 			ChannelIdentitiesRepo:    c.channelIdentitiesRepo,
 			ChannelDMThreadsRepo:     c.channelDMThreadsRepo,
 			ChannelGroupThreadsRepo:  c.channelGroupThreadsRepo,

--- a/src/services/api/internal/http/accountapi/channels_telegram.go
+++ b/src/services/api/internal/http/accountapi/channels_telegram.go
@@ -1853,6 +1853,7 @@ func bindChannelIdentity(
 	channelIdentityLinksRepo *data.ChannelIdentityLinksRepository,
 	channelDMThreadsRepo *data.ChannelDMThreadsRepository,
 	threadRepo *data.ThreadRepository,
+	channelsRepo *data.ChannelsRepository,
 ) (string, error) {
 	code = strings.ToUpper(strings.TrimSpace(code))
 	if code == "" {
@@ -1881,6 +1882,9 @@ func bindChannelIdentity(
 				return "", err
 			}
 		}
+		if err := setChannelOwnerIfMissing(ctx, tx, channel, activeCode.IssuedByUserID, channelsRepo); err != nil {
+			return "", err
+		}
 		return "账号已绑定。", nil
 	}
 
@@ -1898,6 +1902,9 @@ func bindChannelIdentity(
 		if _, err := channelIdentityLinksRepo.WithTx(tx).Upsert(ctx, channel.ID, identity.ID); err != nil {
 			return "", err
 		}
+	}
+	if err := setChannelOwnerIfMissing(ctx, tx, channel, consumed.IssuedByUserID, channelsRepo); err != nil {
+		return "", err
 	}
 	threadMappings, err := channelDMThreadsRepo.WithTx(tx).ListByChannelIdentity(ctx, channel.ID, identity.ID)
 	if err != nil {

--- a/src/services/api/internal/http/accountapi/channels_telegram_inbound_stages.go
+++ b/src/services/api/internal/http/accountapi/channels_telegram_inbound_stages.go
@@ -177,6 +177,7 @@ func (c telegramConnector) persistTelegramInboundStageA(
 				},
 			},
 			ChannelCommandDeps{
+				ChannelsRepo:             c.channelsRepo,
 				ChannelIdentitiesRepo:    c.channelIdentitiesRepo,
 				ChannelDMThreadsRepo:     c.channelDMThreadsRepo,
 				ChannelGroupThreadsRepo:  c.channelGroupThreadsRepo,
@@ -245,6 +246,7 @@ func (c telegramConnector) persistTelegramInboundStageA(
 					},
 				},
 				ChannelCommandDeps{
+					ChannelsRepo:             c.channelsRepo,
 					ChannelIdentitiesRepo:    c.channelIdentitiesRepo,
 					ChannelDMThreadsRepo:     c.channelDMThreadsRepo,
 					ChannelGroupThreadsRepo:  c.channelGroupThreadsRepo,

--- a/src/services/api/internal/http/accountapi/channels_weixin.go
+++ b/src/services/api/internal/http/accountapi/channels_weixin.go
@@ -194,6 +194,7 @@ func (c *weixinConnector) HandleWeChatMessage(ctx context.Context, traceID strin
 			},
 		},
 		ChannelCommandDeps{
+			ChannelsRepo:             c.channelsRepo,
 			ChannelIdentitiesRepo:    c.channelIdentitiesRepo,
 			ChannelDMThreadsRepo:     c.channelDMThreadsRepo,
 			ChannelGroupThreadsRepo:  c.channelGroupThreadsRepo,

--- a/src/services/api/internal/http/accountapi/helpers.go
+++ b/src/services/api/internal/http/accountapi/helpers.go
@@ -2,6 +2,7 @@ package accountapi
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	httpkit "arkloop/services/api/internal/http/httpkit"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 )
 
 type environmentStore interface {
@@ -102,6 +104,43 @@ func channelOwnerUserID(ch data.Channel) *uuid.UUID {
 		return ch.OwnerUserID
 	}
 	return nil
+}
+
+func setChannelOwnerIfMissing(ctx context.Context, tx pgx.Tx, ch *data.Channel, ownerUserID uuid.UUID, repo *data.ChannelsRepository) error {
+	if ch == nil || ownerUserID == uuid.Nil {
+		return nil
+	}
+	if ch.ID == uuid.Nil || ch.AccountID == uuid.Nil {
+		return fmt.Errorf("channel owner update requires channel id and account id")
+	}
+	if repo == nil {
+		return fmt.Errorf("channels repo not configured")
+	}
+	repoTx := repo
+	if tx != nil {
+		repoTx = repo.WithTx(tx)
+	}
+	updated, err := repoTx.SetOwnerIfMissing(ctx, ch.ID, ch.AccountID, ownerUserID)
+	if err != nil {
+		return err
+	}
+	if updated == nil {
+		return nil
+	}
+	ch.OwnerUserID = updated.OwnerUserID
+	return nil
+}
+
+func clearChannelOwner(ctx context.Context, tx pgx.Tx, repo *data.ChannelsRepository, channelID, accountID, ownerUserID uuid.UUID) error {
+	if repo == nil {
+		return fmt.Errorf("channels repo not configured")
+	}
+	repoTx := repo
+	if tx != nil {
+		repoTx = repo.WithTx(tx)
+	}
+	_, err := repoTx.ClearOwnerIfMatches(ctx, channelID, accountID, ownerUserID)
+	return err
 }
 
 func authorizeRunOrAudit(

--- a/src/services/api/internal/http/accountapi/register.go
+++ b/src/services/api/internal/http/accountapi/register.go
@@ -131,5 +131,5 @@ func RegisterRoutes(mux *nethttp.ServeMux, deps Deps) {
 	mux.HandleFunc("/v1/channels/", channelEntry(deps.AuthService, deps.AccountMembershipRepo, deps.ChannelsRepo, deps.ChannelIdentityLinksRepo, deps.ChannelIdentitiesRepo, deps.ChannelDMThreadsRepo, deps.PersonasRepo, deps.EntitlementService, deps.APIKeysRepo, deps.SecretsRepo, deps.Pool, deps.TelegramBotClient, deps.DiscordBotClient, deps.TelegramMode))
 	mux.HandleFunc("/v1/me/channel-binds", channelBindsEntry(deps.AuthService, deps.AccountMembershipRepo, deps.ChannelBindCodesRepo, deps.APIKeysRepo))
 	mux.HandleFunc("/v1/me/channel-identities", channelIdentitiesEntry(deps.AuthService, deps.AccountMembershipRepo, deps.ChannelIdentitiesRepo, deps.APIKeysRepo))
-	mux.HandleFunc("/v1/me/channel-identities/", channelIdentityEntry(deps.AuthService, deps.AccountMembershipRepo, deps.ChannelIdentitiesRepo, deps.ChannelIdentityLinksRepo, deps.APIKeysRepo, deps.Pool))
+	mux.HandleFunc("/v1/me/channel-identities/", channelIdentityEntry(deps.AuthService, deps.AccountMembershipRepo, deps.ChannelsRepo, deps.ChannelIdentitiesRepo, deps.ChannelIdentityLinksRepo, deps.APIKeysRepo, deps.Pool))
 }

--- a/src/services/api/internal/http/accountapi/telegram_media_group.go
+++ b/src/services/api/internal/http/accountapi/telegram_media_group.go
@@ -281,6 +281,7 @@ func (c telegramConnector) processTelegramMediaGroupMerged(
 				},
 			},
 			ChannelCommandDeps{
+				ChannelsRepo:             c.channelsRepo,
 				ChannelIdentitiesRepo:    c.channelIdentitiesRepo,
 				ChannelDMThreadsRepo:     c.channelDMThreadsRepo,
 				ChannelGroupThreadsRepo:  c.channelGroupThreadsRepo,
@@ -359,6 +360,7 @@ func (c telegramConnector) processTelegramMediaGroupMerged(
 					},
 				},
 				ChannelCommandDeps{
+					ChannelsRepo:             c.channelsRepo,
 					ChannelIdentitiesRepo:    c.channelIdentitiesRepo,
 					ChannelDMThreadsRepo:     c.channelDMThreadsRepo,
 					ChannelGroupThreadsRepo:  c.channelGroupThreadsRepo,

--- a/src/services/api/internal/http/accountapi/v1_channel_bindings.go
+++ b/src/services/api/internal/http/accountapi/v1_channel_bindings.go
@@ -85,7 +85,7 @@ func handleChannelBindingsSubresource(
 	case nethttp.MethodPatch:
 		updateChannelBinding(w, r, traceID, actor.AccountID, channelID, *bindingID, membershipRepo, channelsRepo, personasRepo, channelIdentityLinksRepo, channelIdentitiesRepo, pool)
 	case nethttp.MethodDelete:
-		deleteChannelBinding(w, r, traceID, actor.AccountID, channelID, *bindingID, channelIdentityLinksRepo, channelIdentitiesRepo, channelDMThreadsRepo, pool)
+		deleteChannelBinding(w, r, traceID, actor.AccountID, channelID, *bindingID, channelsRepo, channelIdentityLinksRepo, channelIdentitiesRepo, channelDMThreadsRepo, pool)
 	default:
 		httpkit.WriteMethodNotAllowed(w, r)
 	}
@@ -177,6 +177,7 @@ func deleteChannelBinding(
 	accountID uuid.UUID,
 	channelID uuid.UUID,
 	bindingID uuid.UUID,
+	channelsRepo *data.ChannelsRepository,
 	channelIdentityLinksRepo *data.ChannelIdentityLinksRepository,
 	channelIdentitiesRepo *data.ChannelIdentitiesRepository,
 	channelDMThreadsRepo *data.ChannelDMThreadsRepository,
@@ -201,9 +202,11 @@ func deleteChannelBinding(
 		httpkit.WriteError(w, nethttp.StatusNotFound, "channel_bindings.not_found", "binding not found", traceID, nil)
 		return
 	}
-	if binding.IsOwner {
-		httpkit.WriteError(w, nethttp.StatusConflict, "channel_bindings.owner_unbind_blocked", "owner cannot be unlinked directly", traceID, nil)
-		return
+	if binding.IsOwner && binding.UserID != nil {
+		if err := clearChannelOwner(r.Context(), tx, channelsRepo, channelID, accountID, *binding.UserID); err != nil {
+			httpkit.WriteError(w, nethttp.StatusInternalServerError, "internal.error", "internal error", traceID, nil)
+			return
+		}
 	}
 	if err := dmThreadsRepo.DeleteByChannelIdentity(r.Context(), channelID, binding.ChannelIdentityID); err != nil {
 		httpkit.WriteError(w, nethttp.StatusInternalServerError, "internal.error", "internal error", traceID, nil)

--- a/src/services/api/internal/http/accountapi/v1_channel_binds.go
+++ b/src/services/api/internal/http/accountapi/v1_channel_binds.go
@@ -74,6 +74,7 @@ func channelIdentitiesEntry(
 func channelIdentityEntry(
 	authService *auth.Service,
 	membershipRepo *data.AccountMembershipRepository,
+	channelsRepo *data.ChannelsRepository,
 	identitiesRepo *data.ChannelIdentitiesRepository,
 	channelIdentityLinksRepo *data.ChannelIdentityLinksRepository,
 	apiKeysRepo *data.APIKeysRepository,
@@ -97,7 +98,7 @@ func channelIdentityEntry(
 
 		switch r.Method {
 		case nethttp.MethodDelete:
-			unbindChannelIdentity(w, r, traceID, identityID, authService, membershipRepo, identitiesRepo, channelIdentityLinksRepo, apiKeysRepo, pool)
+			unbindChannelIdentity(w, r, traceID, identityID, authService, membershipRepo, channelsRepo, identitiesRepo, channelIdentityLinksRepo, apiKeysRepo, pool)
 		default:
 			httpkit.WriteMethodNotAllowed(w, r)
 		}
@@ -194,6 +195,7 @@ func unbindChannelIdentity(
 	identityID uuid.UUID,
 	authService *auth.Service,
 	membershipRepo *data.AccountMembershipRepository,
+	channelsRepo *data.ChannelsRepository,
 	identitiesRepo *data.ChannelIdentitiesRepository,
 	channelIdentityLinksRepo *data.ChannelIdentityLinksRepository,
 	apiKeysRepo *data.APIKeysRepository,
@@ -203,7 +205,7 @@ func unbindChannelIdentity(
 		httpkit.WriteAuthNotConfigured(w, traceID)
 		return
 	}
-	if identitiesRepo == nil || channelIdentityLinksRepo == nil || pool == nil {
+	if channelsRepo == nil || identitiesRepo == nil || channelIdentityLinksRepo == nil || pool == nil {
 		httpkit.WriteError(w, nethttp.StatusServiceUnavailable, "database.not_configured", "database not configured", traceID, nil)
 		return
 	}
@@ -223,18 +225,6 @@ func unbindChannelIdentity(
 		return
 	}
 
-	bindings, err := channelIdentityLinksRepo.ListBindingsByIdentity(r.Context(), identityID)
-	if err != nil {
-		httpkit.WriteError(w, nethttp.StatusInternalServerError, "internal.error", "internal error", traceID, nil)
-		return
-	}
-	for _, binding := range bindings {
-		if binding.IsOwner {
-			httpkit.WriteError(w, nethttp.StatusConflict, "channel_bindings.owner_unbind_blocked", "owner cannot be unlinked directly", traceID, nil)
-			return
-		}
-	}
-
 	tx, err := pool.BeginTx(r.Context(), pgx.TxOptions{})
 	if err != nil {
 		httpkit.WriteError(w, nethttp.StatusInternalServerError, "internal.error", "internal error", traceID, nil)
@@ -242,7 +232,22 @@ func unbindChannelIdentity(
 	}
 	defer tx.Rollback(r.Context()) //nolint:errcheck
 
-	if err := channelIdentityLinksRepo.WithTx(tx).DeleteByIdentity(r.Context(), identityID); err != nil {
+	linksRepo := channelIdentityLinksRepo.WithTx(tx)
+	bindings, err := linksRepo.ListBindingsByIdentity(r.Context(), identityID)
+	if err != nil {
+		httpkit.WriteError(w, nethttp.StatusInternalServerError, "internal.error", "internal error", traceID, nil)
+		return
+	}
+	for _, binding := range bindings {
+		if !binding.IsOwner || binding.UserID == nil {
+			continue
+		}
+		if err := clearChannelOwner(r.Context(), tx, channelsRepo, binding.ChannelID, binding.AccountID, *binding.UserID); err != nil {
+			httpkit.WriteError(w, nethttp.StatusInternalServerError, "internal.error", "internal error", traceID, nil)
+			return
+		}
+	}
+	if err := linksRepo.DeleteByIdentity(r.Context(), identityID); err != nil {
 		httpkit.WriteError(w, nethttp.StatusInternalServerError, "internal.error", "internal error", traceID, nil)
 		return
 	}


### PR DESCRIPTION
Summary:
- restore the owner binding synchronization changes from #67 against main
- allow owner binding unlinks by clearing only the matching channel owner
- restore a missing channel owner on bind without overwriting an existing owner
- propagate the channel repository through command dispatch for owner synchronization
- remove owner-unbind blocked text from desktop channel settings

Tests:
- go test -count=1 ./internal/data
- go test -count=1 ./internal/http/accountapi
- pnpm --dir src/apps/web type-check
- git diff --check origin/main...HEAD