### PR TITLE
feat(web): include appearance in data bundles

### DIFF
--- a/src/apps/desktop/src/main/ipc.ts
+++ b/src/apps/desktop/src/main/ipc.ts
@@ -42,8 +42,18 @@ type DesktopExportSection =
   | 'themes'
 
 type DesktopThemeExportPayload = {
+  themePreset?: string | null
   customThemeId: string | null
   customThemes: Record<string, unknown>
+  backgroundImage?: {
+    dataUrl: string
+    name: string
+    mimeType: string
+    size: number
+    updatedAt: number
+  } | null
+  backgroundImageOpacity?: number | null
+  sidebarGrouping?: 'normal' | 'gtd' | null
 }
 
 type DesktopExportOptions = {

--- a/src/apps/desktop/src/preload/index.ts
+++ b/src/apps/desktop/src/preload/index.ts
@@ -229,8 +229,18 @@ export type DesktopExportSection =
   | 'themes'
 
 export type DesktopThemeExportPayload = {
+  themePreset?: string | null
   customThemeId: string | null
   customThemes: Record<string, unknown>
+  backgroundImage?: {
+    dataUrl: string
+    name: string
+    mimeType: string
+    size: number
+    updatedAt: number
+  } | null
+  backgroundImageOpacity?: number | null
+  sidebarGrouping?: 'normal' | 'gtd' | null
 }
 
 export type DesktopExportOptions = {

--- a/src/apps/shared/src/desktop.ts
+++ b/src/apps/shared/src/desktop.ts
@@ -362,8 +362,18 @@ export type DesktopExportSection =
   | 'themes'
 
 export type DesktopThemeExportPayload = {
+  themePreset?: string | null
   customThemeId: string | null
   customThemes: Record<string, unknown>
+  backgroundImage?: {
+    dataUrl: string
+    name: string
+    mimeType: string
+    size: number
+    updatedAt: number
+  } | null
+  backgroundImageOpacity?: number | null
+  sidebarGrouping?: 'normal' | 'gtd' | null
 }
 
 export type DesktopExportOptions = {

--- a/src/apps/web/src/__tests__/advancedSettings.test.tsx
+++ b/src/apps/web/src/__tests__/advancedSettings.test.tsx
@@ -356,4 +356,150 @@ describe('AdvancedSettings', () => {
       }),
     }))
   })
+
+  it('导入主题外观校验失败时不写入部分主题状态', async () => {
+    const saveCustomTheme = vi.fn()
+    const setBackgroundImage = vi.fn(() => true)
+    const setBackgroundImageOpacity = vi.fn()
+    const setThemePreset = vi.fn()
+    const setActiveCustomTheme = vi.fn()
+    const writeGtdEnabled = vi.fn()
+    const desktopApi = {
+      advanced: {
+        getOverview: vi.fn().mockResolvedValue({
+          appName: 'Arkloop',
+          appVersion: '1.2.3',
+          githubUrl: 'https://github.com/qqqqqf-q/Arkloop',
+          telegramUrl: null,
+          iconDataUrl: null,
+          configPath: '/tmp/config.json',
+          dataDir: '/tmp/data',
+          logsDir: '/tmp/logs',
+          sqlitePath: '/tmp/data.db',
+          links: [],
+          status: [],
+          usage: null,
+        }),
+        chooseDataFolder: vi.fn().mockResolvedValue('/tmp/export'),
+        exportDataBundle: vi.fn().mockResolvedValue({ ok: true, filePath: '/tmp/export/bundle' }),
+        importDataBundle: vi.fn().mockResolvedValue({
+          ok: true,
+          importedFrom: '/tmp/import',
+          themes: {
+            themePreset: 'background-image',
+            customThemeId: 'theme-1',
+            customThemes: {
+              'theme-1': { id: 'theme-1', name: 'Theme 1' },
+            },
+            backgroundImage: { dataUrl: 12 },
+            backgroundImageOpacity: 55,
+            sidebarGrouping: 'gtd',
+          },
+        }),
+        listLogs: vi.fn().mockResolvedValue({ entries: [] }),
+      },
+      config: {
+        get: vi.fn().mockResolvedValue({
+          network: {
+            proxyEnabled: false,
+            requestTimeoutMs: 30000,
+            retryCount: 1,
+          },
+        }),
+        set: vi.fn().mockResolvedValue({ ok: true }),
+      },
+    }
+
+    vi.doMock('../storage', async () => {
+      const actual = await vi.importActual<typeof import('../storage')>('../storage')
+      return {
+        ...actual,
+        readLocaleFromStorage: vi.fn(() => 'zh'),
+        readGtdEnabled: vi.fn(() => false),
+        writeGtdEnabled,
+        writeLocaleToStorage: vi.fn(),
+      }
+    })
+    vi.doMock('../api', async () => {
+      const actual = await vi.importActual<typeof import('../api')>('../api')
+      return {
+        ...actual,
+        getMyUsage: vi.fn().mockResolvedValue(null),
+        getMyDailyUsage: vi.fn().mockResolvedValue([]),
+        getMyHourlyUsage: vi.fn().mockResolvedValue([]),
+        getMyUsageByModel: vi.fn().mockResolvedValue([]),
+      }
+    })
+    vi.doMock('../components/settings/ConnectionSettings', () => ({
+      ConnectionSettings: () => <div>connection-settings</div>,
+    }))
+    vi.doMock('../components/settings/ModulesSettings', () => ({
+      ModulesSettings: () => <div>modules-settings</div>,
+    }))
+    vi.doMock('../components/settings/ExtensionsSettings', () => ({
+      ExtensionsSettings: () => <div>extensions-settings</div>,
+    }))
+    vi.doMock('../components/settings/UpdateSettings', () => ({
+      UpdateSettingsContent: () => <div>update-settings</div>,
+    }))
+    vi.doMock('../contexts/AppearanceContext', () => ({
+      useAppearance: () => ({
+        themePreset: 'default',
+        setThemePreset,
+        customThemeId: null,
+        customThemes: {},
+        saveCustomTheme,
+        setActiveCustomTheme,
+        backgroundImage: null,
+        setBackgroundImage,
+        backgroundImageOpacity: 40,
+        setBackgroundImageOpacity,
+      }),
+    }))
+    vi.doMock('@arkloop/shared', async () => {
+      const actual = await vi.importActual<typeof import('@arkloop/shared')>('@arkloop/shared')
+      return {
+        ...actual,
+        useToast: () => ({ addToast }),
+      }
+    })
+    vi.doMock('@arkloop/shared/desktop', () => ({
+      getDesktopApi: () => desktopApi,
+    }))
+
+    const { AdvancedSettings } = await import('../components/settings/AdvancedSettings')
+    const { LocaleProvider } = await import('../contexts/LocaleContext')
+
+    await act(async () => {
+      root!.render(
+        <LocaleProvider>
+          <AdvancedSettings accessToken="token" />
+        </LocaleProvider>,
+      )
+    })
+    await flushEffects()
+
+    const dataButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes('数据'))
+    expect(dataButton).toBeTruthy()
+
+    await act(async () => {
+      dataButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await flushEffects()
+
+    const importButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes('导入数据'))
+    expect(importButton).toBeTruthy()
+
+    await act(async () => {
+      importButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await flushEffects()
+
+    expect(saveCustomTheme).not.toHaveBeenCalled()
+    expect(setBackgroundImage).not.toHaveBeenCalled()
+    expect(setBackgroundImageOpacity).not.toHaveBeenCalled()
+    expect(setThemePreset).not.toHaveBeenCalled()
+    expect(setActiveCustomTheme).not.toHaveBeenCalled()
+    expect(writeGtdEnabled).not.toHaveBeenCalled()
+  })
 })

--- a/src/apps/web/src/__tests__/advancedSettings.test.tsx
+++ b/src/apps/web/src/__tests__/advancedSettings.test.tsx
@@ -102,6 +102,7 @@ describe('AdvancedSettings', () => {
       return {
         ...actual,
         readLocaleFromStorage: vi.fn(() => 'zh'),
+        readGtdEnabled: vi.fn(() => false),
         writeLocaleToStorage: vi.fn(),
       }
     })
@@ -140,10 +141,16 @@ describe('AdvancedSettings', () => {
     }))
     vi.doMock('../contexts/AppearanceContext', () => ({
       useAppearance: () => ({
+        themePreset: 'default',
+        setThemePreset: vi.fn(),
         customThemeId: null,
         customThemes: {},
         saveCustomTheme: vi.fn(),
         setActiveCustomTheme: vi.fn(),
+        backgroundImage: null,
+        setBackgroundImage: vi.fn(() => true),
+        backgroundImageOpacity: 40,
+        setBackgroundImageOpacity: vi.fn(),
       }),
     }))
     vi.doMock('@arkloop/shared', async () => {
@@ -228,6 +235,7 @@ describe('AdvancedSettings', () => {
       return {
         ...actual,
         readLocaleFromStorage: vi.fn(() => 'zh'),
+        readGtdEnabled: vi.fn(() => true),
         writeLocaleToStorage: vi.fn(),
       }
     })
@@ -255,10 +263,22 @@ describe('AdvancedSettings', () => {
     }))
     vi.doMock('../contexts/AppearanceContext', () => ({
       useAppearance: () => ({
+        themePreset: 'background-image',
+        setThemePreset: vi.fn(),
         customThemeId: null,
         customThemes: {},
         saveCustomTheme: vi.fn(),
         setActiveCustomTheme: vi.fn(),
+        backgroundImage: {
+          dataUrl: 'data:image/png;base64,Ymc=',
+          name: 'bg.png',
+          mimeType: 'image/png',
+          size: 2,
+          updatedAt: 1234,
+        },
+        setBackgroundImage: vi.fn(() => true),
+        backgroundImageOpacity: 55,
+        setBackgroundImageOpacity: vi.fn(),
       }),
     }))
     vi.doMock('@arkloop/shared', async () => {
@@ -311,5 +331,29 @@ describe('AdvancedSettings', () => {
       '自定义主题',
     ])
     expect(exportDataBundle).not.toHaveBeenCalled()
+
+    const exportLabel = exportButton!.textContent?.trim()
+    const confirmExportButton = Array.from(document.body.querySelectorAll('button'))
+      .filter((button) => button.textContent?.trim() === exportLabel)
+      .at(-1)
+    expect(confirmExportButton).toBeTruthy()
+
+    await act(async () => {
+      confirmExportButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await flushEffects()
+
+    expect(exportDataBundle).toHaveBeenCalledWith(expect.objectContaining({
+      sections: expect.arrayContaining(['themes']),
+      themes: expect.objectContaining({
+        themePreset: 'background-image',
+        backgroundImage: expect.objectContaining({
+          dataUrl: 'data:image/png;base64,Ymc=',
+          name: 'bg.png',
+        }),
+        backgroundImageOpacity: 55,
+        sidebarGrouping: 'gtd',
+      }),
+    }))
   })
 })

--- a/src/apps/web/src/__tests__/appearanceStorage.test.ts
+++ b/src/apps/web/src/__tests__/appearanceStorage.test.ts
@@ -4,9 +4,12 @@ import type { ThemeBackgroundImage } from '../themes/types'
 import {
   readBackgroundImageFromStorage,
   readBackgroundImageOpacityFromStorage,
+  readGtdEnabled,
   readThemePresetFromStorage,
+  subscribeGtdEnabled,
   writeBackgroundImageToStorage,
   writeBackgroundImageOpacityToStorage,
+  writeGtdEnabled,
   writeThemePresetToStorage,
 } from '../storage'
 
@@ -104,5 +107,20 @@ describe('appearance storage', () => {
   it('stores the custom background color scheme', () => {
     writeThemePresetToStorage('background-image')
     expect(readThemePresetFromStorage()).toBe('background-image')
+  })
+
+  it('同步 GTD 分组状态变更', () => {
+    const observed: boolean[] = []
+    const unsubscribe = subscribeGtdEnabled((enabled) => observed.push(enabled))
+
+    writeGtdEnabled(true)
+    expect(readGtdEnabled()).toBe(true)
+    expect(observed).toEqual([true])
+
+    writeGtdEnabled(false)
+    expect(readGtdEnabled()).toBe(false)
+    expect(observed).toEqual([true, false])
+
+    unsubscribe()
   })
 })

--- a/src/apps/web/src/__tests__/appearanceStorage.test.ts
+++ b/src/apps/web/src/__tests__/appearanceStorage.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ThemeBackgroundImage } from '../themes/types'
 import {
@@ -120,6 +120,28 @@ describe('appearance storage', () => {
     writeGtdEnabled(false)
     expect(readGtdEnabled()).toBe(false)
     expect(observed).toEqual([true, false])
+
+    unsubscribe()
+  })
+
+  it('storage 写入失败时仍广播 GTD 分组变更', () => {
+    const storage = createMemoryStorage()
+    const failingStorage = {
+      ...storage,
+      setItem: vi.fn(() => {
+        throw new Error('quota')
+      }),
+    } as Storage
+    Object.defineProperty(globalThis, 'localStorage', { value: failingStorage, configurable: true })
+    Object.defineProperty(window, 'localStorage', { value: failingStorage, configurable: true })
+
+    const observed: boolean[] = []
+    const unsubscribe = subscribeGtdEnabled((enabled) => observed.push(enabled))
+
+    writeGtdEnabled(true)
+
+    expect(observed).toEqual([true])
+    expect(readGtdEnabled()).toBe(false)
 
     unsubscribe()
   })

--- a/src/apps/web/src/components/Sidebar.tsx
+++ b/src/apps/web/src/components/Sidebar.tsx
@@ -39,7 +39,7 @@ import {
   readGtdSomedayThreadIds, writeGtdSomedayThreadIds,
   readGtdArchivedThreadIds, writeGtdArchivedThreadIds,
   readPinnedThreadIds, writePinnedThreadIds,
-  readGtdEnabled, readExpandedProjectPaths, writeExpandedProjectPaths,
+  readGtdEnabled, readExpandedProjectPaths, subscribeGtdEnabled, writeExpandedProjectPaths,
   clearThreadWorkFolder, readThreadWorkFolder, writeThreadWorkFolder, clearWorkFolder, writeWorkFolder,
 } from '../storage'
 
@@ -61,7 +61,6 @@ const PROJECT_GROUP_SECONDARY_PAGE_SIZE = 2
 const PROJECT_GROUP_LABEL_WEIGHT = 'var(--c-sidebar-thread-weight)'
 const SIDEBAR_ROW_TEXT_SIZE = '13.5px'
 const SIDEBAR_ROW_LINE_HEIGHT = '20px'
-const GTD_ENABLED_STORAGE_KEY = 'arkloop:web:gtd_enabled'
 const DRAG_START_DISTANCE_PX = 3
 const DRAG_LONG_PRESS_DELAY_MS = 180
 const GTD_BUCKETS: readonly GtdBucket[] = ['inbox', 'todo', 'waiting', 'someday', 'archived']
@@ -1221,20 +1220,7 @@ export const Sidebar = memo(function Sidebar({
   }, [deleteConfirmThreadId])
 
   useEffect(() => {
-    const handler = (e: Event) => {
-      const enabled = (e as CustomEvent<boolean>).detail
-      setGtdEnabled(enabled)
-    }
-    const storageHandler = (e: StorageEvent) => {
-      if (e.key !== GTD_ENABLED_STORAGE_KEY) return
-      setGtdEnabled(e.newValue === 'true')
-    }
-    window.addEventListener('arkloop:gtd-enabled-changed', handler)
-    window.addEventListener('storage', storageHandler)
-    return () => {
-      window.removeEventListener('arkloop:gtd-enabled-changed', handler)
-      window.removeEventListener('storage', storageHandler)
-    }
+    return subscribeGtdEnabled(setGtdEnabled)
   }, [])
 
   // 监听 work folder 变更，触发重新渲染

--- a/src/apps/web/src/components/settings/AdvancedSettings.tsx
+++ b/src/apps/web/src/components/settings/AdvancedSettings.tsx
@@ -135,6 +135,13 @@ function applySidebarGrouping(value: unknown): void {
   writeGtdEnabled(value === 'gtd')
 }
 
+function collectImportedCustomThemes(value: unknown): ThemeDefinition[] {
+  if (!value || typeof value !== 'object') return []
+  return Object.values(value).filter((item): item is ThemeDefinition => (
+    !!item && typeof item === 'object' && 'id' in item && typeof item.id === 'string'
+  ))
+}
+
 function formatUsd(value: number) {
   return `$${value.toFixed(4)}`
 }
@@ -1118,13 +1125,7 @@ function DataPane({ onReloadOverview }: { onReloadOverview: () => Promise<void> 
         return
       }
       const importedThemes = result.themes
-      if (importedThemes?.customThemes && typeof importedThemes.customThemes === 'object') {
-        for (const value of Object.values(importedThemes.customThemes)) {
-          if (value && typeof value === 'object' && 'id' in value && typeof value.id === 'string') {
-            saveCustomTheme(value as ThemeDefinition)
-          }
-        }
-      }
+      const importedCustomThemes = collectImportedCustomThemes(importedThemes?.customThemes)
       let hasImportedBackground = false
       let importedBackground: ThemeBackgroundImage | null = null
       if (importedThemes && 'backgroundImage' in importedThemes) {
@@ -1135,23 +1136,33 @@ function DataPane({ onReloadOverview }: { onReloadOverview: () => Promise<void> 
         importedBackground = backgroundResult.value
         hasImportedBackground = true
       }
+      const importedBackgroundOpacity = typeof importedThemes?.backgroundImageOpacity === 'number' && Number.isFinite(importedThemes.backgroundImageOpacity)
+        ? importedThemes.backgroundImageOpacity
+        : null
+      const importedSidebarGrouping = importedThemes?.sidebarGrouping
+      const importedThemePreset = importedThemes?.themePreset
+      const importedCustomThemeId = importedThemes?.customThemeId
+
       if (hasImportedBackground && !setBackgroundImage(importedBackground)) {
         throw new Error(t.requestFailed)
       }
-      if (typeof importedThemes?.backgroundImageOpacity === 'number' && Number.isFinite(importedThemes.backgroundImageOpacity)) {
-        setBackgroundImageOpacity(importedThemes.backgroundImageOpacity)
+      for (const theme of importedCustomThemes) {
+        saveCustomTheme(theme)
       }
-      applySidebarGrouping(importedThemes?.sidebarGrouping)
-      if (isThemePreset(importedThemes?.themePreset)) {
-        if (importedThemes.themePreset === 'custom' && importedThemes.customThemeId) {
-          setActiveCustomTheme(importedThemes.customThemeId)
-        } else if (importedThemes.themePreset === 'background-image') {
+      if (importedBackgroundOpacity !== null) {
+        setBackgroundImageOpacity(importedBackgroundOpacity)
+      }
+      applySidebarGrouping(importedSidebarGrouping)
+      if (isThemePreset(importedThemePreset)) {
+        if (importedThemePreset === 'custom' && importedCustomThemeId) {
+          setActiveCustomTheme(importedCustomThemeId)
+        } else if (importedThemePreset === 'background-image') {
           setThemePreset('background-image')
         } else {
-          setThemePreset(importedThemes.themePreset)
+          setThemePreset(importedThemePreset)
         }
-      } else if (importedThemes?.customThemeId) {
-        setActiveCustomTheme(importedThemes.customThemeId)
+      } else if (importedCustomThemeId) {
+        setActiveCustomTheme(importedCustomThemeId)
       }
       addToast(ds.advancedImportDone, 'success')
       await onReloadOverview()

--- a/src/apps/web/src/components/settings/AdvancedSettings.tsx
+++ b/src/apps/web/src/components/settings/AdvancedSettings.tsx
@@ -32,7 +32,8 @@ import type { MeDailyUsageItem, MeHourlyUsageItem, MeModelUsageItem, MeUsageSumm
 import { getMyDailyUsage, getMyHourlyUsage, getMyUsage, getMyUsageByModel } from '../../api'
 import { useAppearance } from '../../contexts/AppearanceContext'
 import { useLocale } from '../../contexts/LocaleContext'
-import type { ThemeDefinition } from '../../themes/types'
+import type { ThemeBackgroundImage, ThemeDefinition, ThemePreset } from '../../themes/types'
+import { readGtdEnabled, writeGtdEnabled } from '../../storage'
 import { SettingsSection } from './_SettingsSection'
 import { SettingsSectionHeader } from './_SettingsSectionHeader'
 import { settingsInputCls } from './_SettingsInput'
@@ -78,6 +79,7 @@ const DESKTOP_EXPORT_SECTIONS: DesktopExportSection[] = [
 
 const AGENT_IMPORT_ITEM_KEYS = ['identity', 'skills', 'mcp', 'providers'] as const
 const AGENT_IMPORT_SOURCE_ORDER: ImportSourceKind[] = ['openclaw', 'hermes']
+const THEME_PRESETS: readonly ThemePreset[] = ['default', 'terra', 'github', 'nord', 'catppuccin', 'tokyo-night', 'retina-burn', 'background-image', 'custom']
 
 function createDefaultAgentImportSelection(): Record<ImportItemKey, boolean> {
   return {
@@ -93,6 +95,44 @@ function createAgentImportSelections(sources: AgentImportDiscovery[]): AgentImpo
     acc[source.kind] = createDefaultAgentImportSelection()
     return acc
   }, {})
+}
+
+function isThemePreset(value: unknown): value is ThemePreset {
+  return typeof value === 'string' && THEME_PRESETS.includes(value as ThemePreset)
+}
+
+type ThemeBackgroundImageImport =
+  | { valid: true; value: ThemeBackgroundImage | null }
+  | { valid: false }
+
+function normalizeThemeBackgroundImage(value: unknown): ThemeBackgroundImageImport {
+  if (value === null) return { valid: true, value: null }
+  if (!value || typeof value !== 'object') return { valid: false }
+  const image = value as Record<string, unknown>
+  if (
+    typeof image.dataUrl !== 'string' ||
+    typeof image.name !== 'string' ||
+    typeof image.mimeType !== 'string' ||
+    typeof image.size !== 'number' ||
+    typeof image.updatedAt !== 'number'
+  ) {
+    return { valid: false }
+  }
+  return {
+    valid: true,
+    value: {
+      dataUrl: image.dataUrl,
+      name: image.name,
+      mimeType: image.mimeType,
+      size: image.size,
+      updatedAt: image.updatedAt,
+    },
+  }
+}
+
+function applySidebarGrouping(value: unknown): void {
+  if (value !== 'normal' && value !== 'gtd') return
+  writeGtdEnabled(value === 'gtd')
 }
 
 function formatUsd(value: number) {
@@ -962,7 +1002,18 @@ function DataPane({ onReloadOverview }: { onReloadOverview: () => Promise<void> 
   const ob = t.onboarding
   const api = getDesktopApi()
   const { addToast } = useToast()
-  const { customThemeId, customThemes, saveCustomTheme, setActiveCustomTheme } = useAppearance()
+  const {
+    themePreset,
+    setThemePreset,
+    customThemeId,
+    customThemes,
+    saveCustomTheme,
+    setActiveCustomTheme,
+    backgroundImage,
+    setBackgroundImage,
+    backgroundImageOpacity,
+    setBackgroundImageOpacity,
+  } = useAppearance()
   const [actionLoading, setActionLoading] = useState<'choose' | 'export' | 'import' | null>(null)
   const [actionError, setActionError] = useState('')
   const [exportDialogOpen, setExportDialogOpen] = useState(false)
@@ -1034,8 +1085,12 @@ function DataPane({ onReloadOverview }: { onReloadOverview: () => Promise<void> 
       const result = await api.advanced.exportDataBundle({
         sections: selectedSections,
         themes: {
+          themePreset,
           customThemeId,
           customThemes: selectedSections.includes('themes') ? customThemes : {},
+          backgroundImage: selectedSections.includes('themes') ? backgroundImage : null,
+          backgroundImageOpacity: selectedSections.includes('themes') ? backgroundImageOpacity : null,
+          sidebarGrouping: selectedSections.includes('themes') ? (readGtdEnabled() ? 'gtd' : 'normal') : null,
         },
       })
       if (result.canceled) {
@@ -1050,7 +1105,7 @@ function DataPane({ onReloadOverview }: { onReloadOverview: () => Promise<void> 
     } finally {
       setActionLoading(null)
     }
-  }, [api, addToast, customThemeId, customThemes, ds.advancedExportCanceled, ds.advancedExportDone, selectedSections, t.requestFailed])
+  }, [api, addToast, backgroundImage, backgroundImageOpacity, customThemeId, customThemes, ds.advancedExportCanceled, ds.advancedExportDone, selectedSections, t.requestFailed, themePreset])
 
   const handleImport = useCallback(async () => {
     if (!api?.advanced) return
@@ -1062,15 +1117,41 @@ function DataPane({ onReloadOverview }: { onReloadOverview: () => Promise<void> 
         addToast(ds.advancedImportCanceled, 'neutral')
         return
       }
-      if (result.themes?.customThemes && typeof result.themes.customThemes === 'object') {
-        for (const value of Object.values(result.themes.customThemes)) {
+      const importedThemes = result.themes
+      if (importedThemes?.customThemes && typeof importedThemes.customThemes === 'object') {
+        for (const value of Object.values(importedThemes.customThemes)) {
           if (value && typeof value === 'object' && 'id' in value && typeof value.id === 'string') {
             saveCustomTheme(value as ThemeDefinition)
           }
         }
-        if (result.themes.customThemeId) {
-          setActiveCustomTheme(result.themes.customThemeId)
+      }
+      let hasImportedBackground = false
+      let importedBackground: ThemeBackgroundImage | null = null
+      if (importedThemes && 'backgroundImage' in importedThemes) {
+        const backgroundResult = normalizeThemeBackgroundImage(importedThemes.backgroundImage)
+        if (!backgroundResult.valid) {
+          throw new Error(t.requestFailed)
         }
+        importedBackground = backgroundResult.value
+        hasImportedBackground = true
+      }
+      if (hasImportedBackground && !setBackgroundImage(importedBackground)) {
+        throw new Error(t.requestFailed)
+      }
+      if (typeof importedThemes?.backgroundImageOpacity === 'number' && Number.isFinite(importedThemes.backgroundImageOpacity)) {
+        setBackgroundImageOpacity(importedThemes.backgroundImageOpacity)
+      }
+      applySidebarGrouping(importedThemes?.sidebarGrouping)
+      if (isThemePreset(importedThemes?.themePreset)) {
+        if (importedThemes.themePreset === 'custom' && importedThemes.customThemeId) {
+          setActiveCustomTheme(importedThemes.customThemeId)
+        } else if (importedThemes.themePreset === 'background-image') {
+          setThemePreset('background-image')
+        } else {
+          setThemePreset(importedThemes.themePreset)
+        }
+      } else if (importedThemes?.customThemeId) {
+        setActiveCustomTheme(importedThemes.customThemeId)
       }
       addToast(ds.advancedImportDone, 'success')
       await onReloadOverview()
@@ -1079,7 +1160,7 @@ function DataPane({ onReloadOverview }: { onReloadOverview: () => Promise<void> 
     } finally {
       setActionLoading(null)
     }
-  }, [api, addToast, ds.advancedImportCanceled, ds.advancedImportDone, onReloadOverview, saveCustomTheme, setActiveCustomTheme, t.requestFailed])
+  }, [api, addToast, ds.advancedImportCanceled, ds.advancedImportDone, onReloadOverview, saveCustomTheme, setActiveCustomTheme, setBackgroundImage, setBackgroundImageOpacity, setThemePreset, t.requestFailed])
 
   const selectedAgentImportSource = selectedAgentImport
     ? agentImportSources.find((source) => source.kind === selectedAgentImport) ?? null

--- a/src/apps/web/src/components/settings/AppearanceSettings.tsx
+++ b/src/apps/web/src/components/settings/AppearanceSettings.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import type { LucideIcon } from 'lucide-react'
 import { Monitor, Sun, Moon } from 'lucide-react'
 import type { Locale } from '../../locales'
 import type { Theme } from '@arkloop/shared/contexts/theme'
 import { useLocale } from '../../contexts/LocaleContext'
 import { useTheme } from '../../contexts/ThemeContext'
-import { readGtdEnabled, writeGtdEnabled } from '../../storage'
+import { readGtdEnabled, subscribeGtdEnabled, writeGtdEnabled } from '../../storage'
 import { FontSettings } from './FontSettings'
 import { ThemePresetPicker } from './ThemePresetPicker'
 import { ThemeColorEditor } from './ThemeColorEditor'
@@ -267,6 +267,8 @@ export function SidebarGroupingPicker({ showLabel = true }: { showLabel?: boolea
   const [gtdEnabled, setGtdEnabled] = useState(() => readGtdEnabled())
   const [hoveredValue, setHoveredValue] = useState<boolean | null>(null)
 
+  useEffect(() => subscribeGtdEnabled(setGtdEnabled), [])
+
   const options: { value: boolean; label: string; Preview: () => React.JSX.Element }[] = [
     { value: false, label: t.sidebarGroupingNormal, Preview: NormalPreview },
     { value: true, label: t.sidebarGroupingGtd, Preview: GtdPreview },
@@ -294,11 +296,6 @@ export function SidebarGroupingPicker({ showLabel = true }: { showLabel?: boolea
                 if (gtdEnabled === value) return
                 setGtdEnabled(value)
                 writeGtdEnabled(value)
-                window.dispatchEvent(new CustomEvent('arkloop:gtd-enabled-changed', { detail: value }))
-                window.dispatchEvent(new StorageEvent('storage', {
-                  key: 'arkloop:web:gtd_enabled',
-                  newValue: String(value),
-                }))
               }}
               className="flex flex-col items-center gap-2"
             >

--- a/src/apps/web/src/storage.ts
+++ b/src/apps/web/src/storage.ts
@@ -2486,12 +2486,13 @@ export function writeBackgroundImageOpacityToStorage(opacity: number): void {
 
 // -- Sidebar View & GTD --
 
-const GTD_ENABLED_KEY = 'arkloop:web:gtd_enabled'
+export const GTD_ENABLED_STORAGE_KEY = 'arkloop:web:gtd_enabled'
+const GTD_ENABLED_CHANGED_EVENT = 'arkloop:gtd-enabled-changed'
 
 export function readGtdEnabled(): boolean {
   if (!canUseLocalStorage()) return false
   try {
-    return localStorage.getItem(GTD_ENABLED_KEY) === 'true'
+    return localStorage.getItem(GTD_ENABLED_STORAGE_KEY) === 'true'
   } catch {
     return false
   }
@@ -2500,8 +2501,32 @@ export function readGtdEnabled(): boolean {
 export function writeGtdEnabled(v: boolean): void {
   if (!canUseLocalStorage()) return
   try {
-    localStorage.setItem(GTD_ENABLED_KEY, String(v))
+    localStorage.setItem(GTD_ENABLED_STORAGE_KEY, String(v))
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent(GTD_ENABLED_CHANGED_EVENT, { detail: v }))
+    }
   } catch { /* ignore */ }
+}
+
+export function subscribeGtdEnabled(listener: (enabled: boolean) => void): () => void {
+  if (typeof window === 'undefined') return () => {}
+
+  const customHandler = (event: Event) => {
+    const enabled = (event as CustomEvent<boolean>).detail
+    listener(typeof enabled === 'boolean' ? enabled : readGtdEnabled())
+  }
+  const storageHandler = (event: StorageEvent) => {
+    if (event.key !== GTD_ENABLED_STORAGE_KEY) return
+    listener(event.newValue === 'true')
+  }
+
+  window.addEventListener(GTD_ENABLED_CHANGED_EVENT, customHandler)
+  window.addEventListener('storage', storageHandler)
+
+  return () => {
+    window.removeEventListener(GTD_ENABLED_CHANGED_EVENT, customHandler)
+    window.removeEventListener('storage', storageHandler)
+  }
 }
 
 const GTD_INBOX_THREAD_IDS_KEY = 'arkloop:web:gtd_inbox_thread_ids'

--- a/src/apps/web/src/storage.ts
+++ b/src/apps/web/src/storage.ts
@@ -2499,13 +2499,14 @@ export function readGtdEnabled(): boolean {
 }
 
 export function writeGtdEnabled(v: boolean): void {
-  if (!canUseLocalStorage()) return
-  try {
-    localStorage.setItem(GTD_ENABLED_STORAGE_KEY, String(v))
-    if (typeof window !== 'undefined') {
-      window.dispatchEvent(new CustomEvent(GTD_ENABLED_CHANGED_EVENT, { detail: v }))
-    }
-  } catch { /* ignore */ }
+  if (canUseLocalStorage()) {
+    try {
+      localStorage.setItem(GTD_ENABLED_STORAGE_KEY, String(v))
+    } catch { /* ignore */ }
+  }
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(GTD_ENABLED_CHANGED_EVENT, { detail: v }))
+  }
 }
 
 export function subscribeGtdEnabled(listener: (enabled: boolean) => void): () => void {


### PR DESCRIPTION
Split from #63.

内容：
- 桌面端“导出数据 / 导入数据”的 themes section 额外携带 themePreset、backgroundImage、backgroundImageOpacity
- 数据导入时恢复这些外观字段
- 数据导出/导入同步 sidebarGrouping
- 集中 GTD enabled storage 订阅逻辑，Sidebar 与 AppearanceSettings 复用同一入口

说明：
- 这不是独立的“主题导入/导出”入口；入口仍然是高级设置里的数据导入/导出。

验证：
- pnpm test -- src/__tests__/appearanceStorage.test.ts src/__tests__/advancedSettings.test.tsx
- pnpm type-check 受 main 既有 modelPicker.test.tsx is_default 类型错误阻塞