### PR TITLE
perf: eliminate QEMU and add caching to release workflows

### DIFF
--- a/.github/workflows/build-desktop.yaml
+++ b/.github/workflows/build-desktop.yaml
@@ -71,6 +71,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.work
+          cache-dependency-path: |
+            src/services/*/go.sum
 
       - name: Build sidecar
         run: |
@@ -134,14 +136,17 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.work
+          cache-dependency-path: |
+            src/services/*/go.sum
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -220,15 +225,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.work
+          cache-dependency-path: |
+            src/services/*/go.sum
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
 
       - name: Resolve release metadata
         id: release_meta
@@ -237,8 +248,18 @@ jobs:
           FALLBACK_VERSION="$(node -p "require('./src/apps/desktop/package.json').version")" \
             node .github/scripts/resolve-release-version.mjs
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Cache Electron
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+            ~/AppData/Local/electron/Cache
+            ~/AppData/Local/electron-builder/Cache
+          key: electron-${{ matrix.os }}-${{ hashFiles('src/apps/desktop/package.json') }}
+          restore-keys: electron-${{ matrix.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -100,7 +100,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digest-${{ matrix.name }}-${{ matrix.platform.suffix }}
+          name: digest-${{ matrix.name }}--${{ matrix.platform.suffix }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -121,7 +121,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digest-${{ matrix.name }}-*
+          pattern: digest-${{ matrix.name }}--*
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -14,11 +14,22 @@ permissions:
   packages: write
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Build each image on native runners (no QEMU emulation)
+  # ---------------------------------------------------------------------------
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
       matrix:
+        name: [api, gateway, worker, sandbox, console, console-lite, bridge]
+        platform:
+          - arch: linux/amd64
+            runner: ubuntu-latest
+            suffix: amd64
+          - arch: linux/arm64
+            runner: ubuntu-24.04-arm
+            suffix: arm64
         include:
           - name: api
             dockerfile: src/services/api/Dockerfile
@@ -52,8 +63,66 @@ jobs:
           INPUT_VERSION="${{ inputs.version }}" \
             node .github/scripts/resolve-release-version.mjs
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/qqqqqf-q/arkloop-${{ matrix.name }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platform.arch }}
+          outputs: type=image,"name=ghcr.io/qqqqqf-q/arkloop-${{ matrix.name }}",push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}-${{ matrix.platform.suffix }}
+          cache-to: type=gha,scope=${{ matrix.name }}-${{ matrix.platform.suffix }},mode=max,ignore-error=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.name }}-${{ matrix.platform.suffix }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Merge per-arch digests into multi-platform manifests
+  # ---------------------------------------------------------------------------
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [api, gateway, worker, sandbox, console, console-lite, bridge]
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-${{ matrix.name }}-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -76,14 +145,9 @@ jobs:
             type=sha,prefix=sha-
             type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/qqqqqf-q/arkloop-${{ matrix.name }}@sha256:%s ' *)

--- a/src/apps/web/src/components/ChatView.tsx
+++ b/src/apps/web/src/components/ChatView.tsx
@@ -281,8 +281,12 @@ type LocationState = {
   forkBaseCount?: number
   userEnterMessageId?: string
   welcomeUserMessage?: AgentMessage
-  graphFocusMessageId?: string
+  cursorMessageId?: string
 } | null
+
+type ConversationCursor =
+  | { kind: 'tail'; threadId: string }
+  | { kind: 'message'; threadId: string; messageId: string }
 
 type RightPanelStoredTab =
   | { id: string; kind: 'source'; title: string; messageId: string }
@@ -952,7 +956,7 @@ export const ChatView = memo(function ChatView() {
   const [webPanelResource, setWebPanelResource] = useState<BrowserResourceRef | null>(null)
   const [extraBrowserTabs, setExtraBrowserTabs] = useState<Array<{ id: string; resource: BrowserResourceRef | null }>>([])
   const [filesPreviewResource, setFilesPreviewResource] = useState<LocalFileResourceRef | null>(null)
-  const [selectedGraphMessageId, setSelectedGraphMessageId] = useState<string | null>(null)
+  const [conversationCursor, setConversationCursor] = useState<ConversationCursor>(() => ({ kind: 'tail', threadId }))
   const browserTabSeqRef = useRef(0)
   const localFileTabSeqRef = useRef(0)
   const restoredRightPanelThreadRef = useRef<string | null>(null)
@@ -1156,9 +1160,8 @@ export const ChatView = memo(function ChatView() {
     (sending || activeRunId != null)
 
   const messageListRef = useRef<MessageListHandle>(null)
-  const graphNavigationHandoffRef = useRef<{ threadId: string; messageId: string; messages: AgentMessage[] } | null>(null)
   const selectForkAnchor = useCallback((messageId: string) => {
-    setSelectedGraphMessageId(messageId)
+    setConversationCursor({ kind: 'message', threadId, messageId })
     setRightPanelVisible(true)
     setActiveRightPanelTabId('conversation-graph')
     setRightPanelWidth((current) => {
@@ -1171,7 +1174,7 @@ export const ChatView = memo(function ChatView() {
     window.requestAnimationFrame(() => {
       messageListRef.current?.scrollToMessage(messageId, { align: 'center', behavior: 'smooth' })
     })
-  }, [])
+  }, [threadId])
 
   const {
     bottomRef,
@@ -1253,25 +1256,15 @@ export const ChatView = memo(function ChatView() {
     const syncVersion = beginMessageSync()
     let disposed = false
     const navUserEnterMessageId = locationState?.userEnterMessageId
-    const navGraphFocusMessageId = locationState?.graphFocusMessageId
-    const graphHandoff = graphNavigationHandoffRef.current
-    const hasGraphHandoff = !!(
-      graphHandoff &&
-      graphHandoff.threadId === threadId &&
-      graphHandoff.messageId === navGraphFocusMessageId
-    )
+    const navCursorMessageId = locationState?.cursorMessageId
 
     if (!shouldSkipInitialSkeleton) {
-      setMessagesLoading(!hasGraphHandoff)
+      setMessagesLoading(true)
       setUserEnterMessageId(null)
     } else if (welcomeUserMessage) {
       setMessages([welcomeUserMessage])
       setUserEnterMessageId(welcomeUserMessage.id)
       setMessagesLoading(false)
-    }
-    if (hasGraphHandoff) {
-      setMessages(graphHandoff.messages)
-      setSelectedGraphMessageId(navGraphFocusMessageId ?? null)
     }
     setError(null)
     setInjectionBlocked(null)
@@ -1285,12 +1278,11 @@ export const ChatView = memo(function ChatView() {
       try {
         const [thread, initialItems, runs] = await Promise.all([
           getThread(accessToken, threadId),
-          hasGraphHandoff ? Promise.resolve(graphHandoff.messages) : agentClient.listMessages(threadId),
+          agentClient.listMessages(threadId),
           listThreadRuns(accessToken, threadId, 1),
         ])
         if (disposed || !isMessageSyncCurrent(syncVersion)) return
         onThreadUpserted(thread)
-        if (hasGraphHandoff) graphNavigationHandoffRef.current = null
 
         const latest = runs[0]
         let items = initialItems
@@ -1304,10 +1296,10 @@ export const ChatView = memo(function ChatView() {
 
         loadedItems = items
         setMessages(items)
-        setSelectedGraphMessageId(
-          navGraphFocusMessageId && items.some((item) => item.id === navGraphFocusMessageId)
-            ? navGraphFocusMessageId
-            : null,
+        setConversationCursor(
+          navCursorMessageId && items.some((item) => item.id === navCursorMessageId)
+            ? { kind: 'message', threadId, messageId: navCursorMessageId }
+            : { kind: 'tail', threadId },
         )
         let interruptedError = latest?.status === 'interrupted'
           ? { message: t.runInterrupted }
@@ -1754,11 +1746,11 @@ export const ChatView = memo(function ChatView() {
             setUserEnterMessageId(navUserEnterMessageId)
           }
           setMessagesLoading(false)
-          if (locationState?.userEnterMessageId || locationState?.welcomeUserMessage || locationState?.graphFocusMessageId) {
+          if (locationState?.userEnterMessageId || locationState?.welcomeUserMessage || locationState?.cursorMessageId) {
             const rest: LocationState = { ...locationState }
             delete rest.userEnterMessageId
             delete rest.welcomeUserMessage
-            delete rest.graphFocusMessageId
+            delete rest.cursorMessageId
             queueMicrotask(() => {
               navigate('.', { replace: true, state: Object.keys(rest as object).length > 0 ? rest : undefined })
             })
@@ -1901,34 +1893,32 @@ export const ChatView = memo(function ChatView() {
   pendingIncognitoRef.current = pendingIncognito
   const messagesRef = useRef(messages)
   messagesRef.current = messages
+  const cursorMessageId = conversationCursor.kind === 'message' && conversationCursor.threadId === threadId
+    ? conversationCursor.messageId
+    : null
   const displayedMessages = useMemo(() => {
-    if (!selectedGraphMessageId) return messages
-    const index = messages.findIndex((message) => message.id === selectedGraphMessageId)
+    if (!cursorMessageId) return messages
+    const index = messages.findIndex((message) => message.id === cursorMessageId)
     return index < 0 ? messages : messages.slice(0, index + 1)
-  }, [messages, selectedGraphMessageId])
-  const selectedGraphMessageIdRef = useRef<string | null>(selectedGraphMessageId)
-  selectedGraphMessageIdRef.current = selectedGraphMessageId
+  }, [messages, cursorMessageId])
+  const conversationCursorRef = useRef<ConversationCursor>(conversationCursor)
+  conversationCursorRef.current = conversationCursor
   useEffect(() => {
-    if (!selectedGraphMessageId) return
-    if (!messages.some((message) => message.id === selectedGraphMessageId)) setSelectedGraphMessageId(null)
-  }, [messages, selectedGraphMessageId])
+    if (conversationCursor.kind !== 'message' || conversationCursor.threadId !== threadId) return
+    if (!messages.some((message) => message.id === conversationCursor.messageId)) {
+      setConversationCursor({ kind: 'tail', threadId })
+    }
+  }, [conversationCursor, messages, threadId])
   const handleSelectGraphMessage = useCallback((targetThreadId: string, messageId: string) => {
     if (targetThreadId !== threadId) {
-      void agentClient.listMessages(targetThreadId)
-        .then((items) => {
-          graphNavigationHandoffRef.current = { threadId: targetThreadId, messageId, messages: items }
-          navigate(`/t/${targetThreadId}`, { state: { graphFocusMessageId: messageId } })
-        })
-        .catch((err) => {
-          setError(normalizeError(err))
-        })
+      navigate(`/t/${targetThreadId}`, { state: { cursorMessageId: messageId } })
       return
     }
-    setSelectedGraphMessageId(messageId)
+    setConversationCursor({ kind: 'message', threadId, messageId })
     window.requestAnimationFrame(() => {
       messageListRef.current?.scrollToMessage(messageId, { align: 'center', behavior: 'smooth' })
     })
-  }, [agentClient, navigate, threadId])
+  }, [navigate, threadId])
   const draftScope = useMemo<InputDraftScope>(() => ({
     ownerKey: me?.id,
     page: 'thread',
@@ -2319,16 +2309,19 @@ export const ChatView = memo(function ChatView() {
         setError({ message: 'Attachments are still uploading.' })
         return
       }
-      const graphForkAnchorMessageId = selectedGraphMessageIdRef.current
-      const graphForkAnchorIndex = graphForkAnchorMessageId
-        ? messages.findIndex((message) => message.id === graphForkAnchorMessageId)
+      const cursor = conversationCursorRef.current
+      const forkAnchorMessageId = cursor.kind === 'message' && cursor.threadId === threadId
+        ? cursor.messageId
+        : null
+      const forkAnchorIndex = forkAnchorMessageId
+        ? messages.findIndex((message) => message.id === forkAnchorMessageId)
         : -1
-      const shouldForkFromGraphSelection =
-        graphForkAnchorMessageId != null &&
-        graphForkAnchorIndex >= 0 &&
-        messages[messages.length - 1]?.id !== graphForkAnchorMessageId
-      if (shouldForkFromGraphSelection) {
-        setSelectedGraphMessageId(null)
+      const shouldForkFromCursor =
+        forkAnchorMessageId != null &&
+        forkAnchorIndex >= 0 &&
+        messages[messages.length - 1]?.id !== forkAnchorMessageId
+      if (shouldForkFromCursor) {
+        setConversationCursor({ kind: 'tail', threadId })
         setSending(true)
         setPendingThinking(true)
         setThinkingHint(hint)
@@ -2336,7 +2329,7 @@ export const ChatView = memo(function ChatView() {
         setInjectionBlocked(null)
         injectionBlockedRunIdRef.current = null
         await waitForThreadModeUpdates()
-        const forked = await forkThread(accessToken, threadId, graphForkAnchorMessageId)
+        const forked = await forkThread(accessToken, threadId, forkAnchorMessageId)
         if (forked.id_mapping) migrateMessageMetadata(forked.id_mapping)
         onThreadCreated(forked)
         const forkUserMessage = await agentClient.createMessage({
@@ -2370,7 +2363,7 @@ export const ChatView = memo(function ChatView() {
       const request = buildMessageRequest(text, uploaded)
       const localMessage = buildOptimisticUserMessage(request, clientMessageId)
 
-      setSelectedGraphMessageId(null)
+      setConversationCursor({ kind: 'tail', threadId })
       setSending(true)
       setPendingThinking(true)
       setThinkingHint(hint)
@@ -2522,7 +2515,7 @@ export const ChatView = memo(function ChatView() {
   useEffect(() => {
     skipRightPanelSaveRef.current = true
     const previousThreadId = restoredRightPanelThreadRef.current
-    const isGraphFocusNavigation = !!locationState?.graphFocusMessageId
+    const isCursorNavigation = !!locationState?.cursorMessageId
     if (!threadId) {
       restoredRightPanelThreadRef.current = null
       setRightPanelVisible(false)
@@ -2536,14 +2529,14 @@ export const ChatView = memo(function ChatView() {
       browserTabSeqRef.current = 0
       return
     }
-    if (previousThreadId !== threadId && !isGraphFocusNavigation) {
+    if (previousThreadId !== threadId && !isCursorNavigation) {
       setRightPanelTabs([])
       closePanelRef.current()
     }
     const saved = readThreadRightPanelState(threadId, { workFolder: workPanelFolder })
     restoredRightPanelThreadRef.current = threadId
-    setRightPanelVisible(isGraphFocusNavigation ? true : saved?.visible ?? false)
-    setActiveRightPanelTabId(isGraphFocusNavigation ? 'conversation-graph' : saved?.activeTabId ?? null)
+    setRightPanelVisible(isCursorNavigation ? true : saved?.visible ?? false)
+    setActiveRightPanelTabId(isCursorNavigation ? 'conversation-graph' : saved?.activeTabId ?? null)
     setRightPanelTabOrder(saved?.tabOrder ?? [])
     setWebPanelResource(saved?.web ?? null)
     setExtraBrowserTabs(saved?.browserTabs ?? [])
@@ -2675,7 +2668,7 @@ export const ChatView = memo(function ChatView() {
 
   const closeRightPanelTab = useCallback((id: string) => {
     if (id === 'conversation-graph') {
-      setSelectedGraphMessageId(null)
+      setConversationCursor({ kind: 'tail', threadId })
       setActiveRightPanelTabId((activeId) => activeId === id ? 'web' : activeId)
       return
     }
@@ -2952,12 +2945,12 @@ export const ChatView = memo(function ChatView() {
       <ConversationGraphPanel
         accessToken={accessToken}
         threadId={threadId}
-        selectedMessageId={selectedGraphMessageId}
+        selectedMessageId={cursorMessageId}
         refreshKey={conversationGraphRefreshKey}
         onSelectMessage={handleSelectGraphMessage}
       />
     ),
-  }), [accessToken, conversationGraphRefreshKey, handleSelectGraphMessage, selectedGraphMessageId, t.rightPanel.conversationGraph, threadId])
+  }), [accessToken, conversationGraphRefreshKey, cursorMessageId, handleSelectGraphMessage, t.rightPanel.conversationGraph, threadId])
 
   const resourcePanelTabs = useMemo<RightPanelTab[]>(() => {
     const result: RightPanelTab[] = []
@@ -3608,7 +3601,7 @@ export const ChatView = memo(function ChatView() {
                 lastTurnStartIdx={lastTurnStartIdx}
                 lastTurnRef={lastUserMsgRef}
                 lastUserPromptRef={lastUserPromptRef}
-                lastTurnChildren={!selectedGraphMessageId || messages[messages.length - 1]?.id === selectedGraphMessageId ? lastTurnChildren : undefined}
+                lastTurnChildren={!cursorMessageId || messages[messages.length - 1]?.id === cursorMessageId ? lastTurnChildren : undefined}
                 showRunDetailButton={showRunDetailButton}
                 currentRunCopHeaderOverride={currentRunCopHeaderOverride}
                 handleRetryUserMessage={handleRetryUserMessage}
@@ -3650,7 +3643,7 @@ export const ChatView = memo(function ChatView() {
     openDocumentPanel,
     openResourcePanel,
     sourcePanelMessageId,
-    selectedGraphMessageId,
+    cursorMessageId,
     setRunDetailPanelRunId,
     stabilizeDocumentPanelScroll,
     t.desktopSettings.chatCompactBannerDone,

--- a/src/apps/web/src/components/conversation-graph/ConversationGraphPanel.tsx
+++ b/src/apps/web/src/components/conversation-graph/ConversationGraphPanel.tsx
@@ -164,7 +164,7 @@ export function ConversationGraphPanel({ accessToken, threadId, selectedMessageI
     void Promise.resolve()
       .then(() => {
         if (disposed) return null
-        setLoading(!graphRef.current)
+        setLoading(graphRef.current?.active_thread_id !== threadId)
         setError(null)
         return getConversationGraph(accessToken, threadId)
       })
@@ -185,16 +185,17 @@ export function ConversationGraphPanel({ accessToken, threadId, selectedMessageI
     }
   }, [accessToken, threadId, reloadKey, refreshKey])
 
+  const activeGraph = graph?.active_thread_id === threadId ? graph : null
   const flow = useMemo(() => (
-    graph
-      ? buildConversationGraphFlow(graph, selectedMessageId, {
+    activeGraph
+      ? buildConversationGraphFlow(activeGraph, selectedMessageId, {
         user: t.rightPanel.conversationGraphUser,
         assistant: t.rightPanel.conversationGraphAssistant,
         system: t.rightPanel.conversationGraphSystem,
       })
       : { nodes: [], edges: [] }
   ), [
-    graph,
+    activeGraph,
     selectedMessageId,
     t.rightPanel.conversationGraphAssistant,
     t.rightPanel.conversationGraphSystem,
@@ -206,7 +207,7 @@ export function ConversationGraphPanel({ accessToken, threadId, selectedMessageI
     onSelectMessage(data.threadId, data.messageId)
   }, [onSelectMessage])
 
-  const rootThreadId = graph?.root_thread_id ?? null
+  const rootThreadId = activeGraph?.root_thread_id ?? null
   const savedViewport = rootThreadId ? readGraphViewport(rootThreadId) : null
   const showGraph = graph && flow.nodes.length > 0
 

--- a/src/apps/web/src/contexts/thread-list.tsx
+++ b/src/apps/web/src/contexts/thread-list.tsx
@@ -381,9 +381,16 @@ export function ThreadListProvider({ children }: { children: ReactNode }) {
     for (const thread of [...modeItemsById.values(), ...sidebarMigration.migratedItems]) {
       itemsById.set(thread.id, thread)
     }
+    for (const thread of threadsRef.current) {
+      if (isBranchThread(thread)) itemsById.set(thread.id, thread)
+    }
     const items = sortThreadsByActivity(Array.from(itemsById.values()))
     mirrorSidebarStateToLocal(items, sidebarMigration.failedThreadIds)
     const nextRunning = new Set(items.filter((t) => t.active_run_id != null).map((t) => t.id))
+    for (const threadId of runningThreadIdsRef.current) {
+      const thread = threadsRef.current.find((item) => item.id === threadId)
+      if (thread && isBranchThread(thread)) nextRunning.add(threadId)
+    }
     const completedThreadIds = Array.from(runningThreadIdsRef.current).filter((threadId) => !nextRunning.has(threadId))
     threadsRef.current = items
     setThreads(items)

--- a/src/apps/web/src/hooks/useChatActions.ts
+++ b/src/apps/web/src/hooks/useChatActions.ts
@@ -386,11 +386,9 @@ export function useChatActions({ scrollToBottom, onSelectForkAnchor }: UseChatAc
       })
       if (personaKey === SEARCH_PERSONA_KEY) addSearchThreadId(forked.id)
       resetSearchSteps()
-      setActiveRunId(run.id)
       navigate(`/t/${forked.id}`, {
         state: {
           initialRunId: run.id,
-          graphFocusMessageId: forkedMessageId,
         },
       })
       onRunStarted(forked.id)

--- a/src/plugins/activity-recorder/manifest.yaml
+++ b/src/plugins/activity-recorder/manifest.yaml
@@ -194,6 +194,7 @@ mcp_servers:
     transport: stdio
     command: uv
     args: ["tool", "run", "--from", "git+https://github.com/vincent-pli/chrome-history-mcp.git", "chrome-history-mcp"]
+    working_dir: data/chrome-history
     enabled_when:
       - setting: enable_chrome_history
         equals: true

--- a/src/services/api/internal/data/threads_repo.go
+++ b/src/services/api/internal/data/threads_repo.go
@@ -216,7 +216,7 @@ func (r *ThreadRepository) ListForkTree(ctx context.Context, accountID, threadID
 		            expires_at, parent_thread_id, branched_from_message_id, title_locked
 		       FROM threads
 		      WHERE id = $2 AND account_id = $1 AND deleted_at IS NULL
-		     UNION ALL
+		     UNION
 		     SELECT p.id, p.account_id, p.created_by_user_id, p.title, p.created_at, p.updated_at, p.deleted_at,
 		            p.project_id, p.is_private, p.mode, p.collaboration_mode, p.collaboration_mode_revision,
 		            p.learning_mode_enabled, p.sidebar_work_folder, p.sidebar_pinned_at, p.sidebar_gtd_bucket,
@@ -241,7 +241,7 @@ func (r *ThreadRepository) ListForkTree(ctx context.Context, accountID, threadID
 		       FROM threads t
 		       JOIN root ON t.id = root.id
 		      WHERE t.account_id = $1 AND t.deleted_at IS NULL
-		     UNION ALL
+		     UNION
 		     SELECT c.id, c.account_id, c.created_by_user_id, c.title, c.created_at, c.updated_at, c.deleted_at,
 		            c.project_id, c.is_private, c.mode, c.collaboration_mode, c.collaboration_mode_revision,
 		            c.learning_mode_enabled, c.sidebar_work_folder, c.sidebar_pinned_at, c.sidebar_gtd_bucket,
@@ -804,7 +804,6 @@ func (r *ThreadRepository) SearchByQueryWithMode(
 		 WHERE t.account_id = $1
 		   AND t.created_by_user_id = $2
 		   AND t.deleted_at IS NULL
-		   AND t.parent_thread_id IS NULL
 		   AND t.is_private = false`
 	args := []any{accountID, ownerUserID}
 	if normalizedMode != "" {

--- a/src/services/api/internal/http/conversationapi/v1_thread_graph.go
+++ b/src/services/api/internal/http/conversationapi/v1_thread_graph.go
@@ -45,6 +45,11 @@ type threadGraphEdge struct {
 	TargetThreadID string `json:"target_thread_id,omitempty"`
 }
 
+const (
+	maxThreadGraphThreads  = 200
+	maxThreadGraphMessages = 2000
+)
+
 func getThreadGraph(
 	authService *auth.Service,
 	membershipRepo *data.AccountMembershipRepository,
@@ -99,14 +104,25 @@ func getThreadGraph(
 			httpkit.WriteError(w, nethttp.StatusNotFound, "threads.not_found", "thread not found", traceID, nil)
 			return
 		}
+		if len(threads) > maxThreadGraphThreads {
+			httpkit.WriteError(w, nethttp.StatusUnprocessableEntity, "threads.graph_too_large", "thread graph too large", traceID, nil)
+			return
+		}
 
 		threadIDs := make([]uuid.UUID, 0, len(threads))
 		for _, item := range threads {
+			if !authorizeThreadOrAudit(w, r, traceID, actor, "threads.graph", &item, auditWriter) {
+				return
+			}
 			threadIDs = append(threadIDs, item.ID)
 		}
 		messages, err := messageRepo.ListVisibleByThreads(r.Context(), thread.AccountID, threadIDs)
 		if err != nil {
 			writeInternalError(w, traceID, err)
+			return
+		}
+		if len(messages) > maxThreadGraphMessages {
+			httpkit.WriteError(w, nethttp.StatusUnprocessableEntity, "threads.graph_too_large", "thread graph too large", traceID, nil)
 			return
 		}
 

--- a/src/services/api/internal/plugincontrib/manifest_test.go
+++ b/src/services/api/internal/plugincontrib/manifest_test.go
@@ -98,6 +98,29 @@ func TestRenderLaunchSpecResolvesRuntimePath(t *testing.T) {
 	}
 }
 
+func TestRenderLaunchSpecResolvesPluginRelativeCwd(t *testing.T) {
+	pluginData := filepath.Join(t.TempDir(), "plugin-data")
+	payload, err := renderLaunchSpec(map[string]any{
+		"transport": "stdio",
+		"command":   "uv",
+		"cwd":       "data/chrome-history",
+	}, nil, map[string]any{"plugin_data": pluginData}, true)
+	if err != nil {
+		t.Fatalf("render launch spec: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("decode launch spec: %v", err)
+	}
+	expected := filepath.Join(pluginData, "data", "chrome-history")
+	if decoded["cwd"] != expected {
+		t.Fatalf("unexpected cwd: %#v", decoded)
+	}
+	if _, err := os.Stat(expected); err != nil {
+		t.Fatalf("expected cwd to exist: %v", err)
+	}
+}
+
 func TestRenderLaunchSpecResolvesRuntimeCommandHelperAndPlatform(t *testing.T) {
 	spec := map[string]any{
 		"command": "${runtime.cua-driver.command}",

--- a/src/services/api/internal/plugincontrib/service.go
+++ b/src/services/api/internal/plugincontrib/service.go
@@ -841,11 +841,44 @@ func renderLaunchSpec(spec map[string]any, settings map[string]any, runtimeState
 	if err != nil {
 		return nil, err
 	}
+	if renderedMap, ok := rendered.(map[string]any); ok {
+		if err := resolvePluginLaunchCwd(renderedMap, runtimeState); err != nil {
+			return nil, err
+		}
+	}
 	payload, err := json.Marshal(rendered)
 	if err != nil {
 		return nil, err
 	}
 	return payload, nil
+}
+
+func resolvePluginLaunchCwd(spec map[string]any, runtimeState map[string]any) error {
+	raw := launchCwdValue(spec)
+	if raw == "" || filepath.IsAbs(raw) {
+		return nil
+	}
+	pluginData := stringFromPluginMap(runtimeState, "plugin_data")
+	if pluginData == "" {
+		return nil
+	}
+	resolved := filepath.Join(pluginData, raw)
+	if err := os.MkdirAll(resolved, 0o755); err != nil {
+		return err
+	}
+	spec["cwd"] = resolved
+	delete(spec, "working_dir")
+	delete(spec, "workingDir")
+	return nil
+}
+
+func launchCwdValue(spec map[string]any) string {
+	for _, key := range []string{"cwd", "working_dir", "workingDir"} {
+		if value, ok := spec[key]; ok && value != nil {
+			return strings.TrimSpace(fmt.Sprint(value))
+		}
+	}
+	return ""
 }
 
 func renderValue(value any, settings map[string]any, runtimeState map[string]any, strictPlaceholders bool) (any, error) {

--- a/src/services/worker/internal/app/composition_desktop.go
+++ b/src/services/worker/internal/app/composition_desktop.go
@@ -1507,14 +1507,24 @@ func desktopChannelDelivery(db data.DesktopDB, stickerStore interface {
 			}
 		}
 
-		var stopTyping context.CancelFunc
-		if preloaded != nil && ux.TypingIndicator && strings.TrimSpace(preloaded.Token) != "" && pipeline.ShouldSendTelegramTypingRefresh(rc) {
-			stopTyping = pipeline.StartTelegramTypingRefresh(ctx, client, preloaded.Token, rc.ChannelContext.Conversation.Target)
+		var (
+			typingMu   sync.Mutex
+			stopTyping context.CancelFunc
+		)
+		if preloaded != nil && ux.TypingIndicator && strings.TrimSpace(preloaded.Token) != "" && rc != nil && rc.ChannelContext != nil {
+			rc.TelegramVisibleTextDelta = func(context.Context) {
+				typingMu.Lock()
+				defer typingMu.Unlock()
+				if stopTyping == nil {
+					stopTyping = pipeline.StartTelegramTypingRefresh(ctx, client, preloaded.Token, rc.ChannelContext.Conversation.Target)
+				}
+			}
 		}
 
 		err := next(ctx, rc)
 		if rc != nil {
 			rc.TelegramToolBoundaryFlush = nil
+			rc.TelegramVisibleTextDelta = nil
 			if rc.TelegramProgressTracker != nil {
 				rc.TelegramProgressTracker.Finalize(ctx)
 			}
@@ -3399,8 +3409,13 @@ func desktopAgentLoop(
 			responseDraftStore:      rc.ResponseDraftStore,
 			telegramBoundaryFlush:   rc.TelegramToolBoundaryFlush,
 			telegramProgressTracker: rc.TelegramProgressTracker,
-			heartbeatRun:            pipeline.IsHeartbeatRunContext(rc),
-			streamThinking:          rc.StreamThinking,
+			telegramVisibleTextDelta: func(ctx context.Context, role, channel, delta string) {
+				if pipeline.IsVisibleAssistantTextDelta(rc, role, channel, delta) && rc.TelegramVisibleTextDelta != nil {
+					rc.TelegramVisibleTextDelta(ctx)
+				}
+			},
+			heartbeatRun:   pipeline.IsHeartbeatRunContext(rc),
+			streamThinking: rc.StreamThinking,
 		}
 		personaID := ""
 		if rc.PersonaDefinition != nil {
@@ -3532,6 +3547,7 @@ type desktopEventWriter struct {
 	totalCostUSD             float64
 	usageRepo                data.UsageRecordsRepository
 	telegramBoundaryFlush    func(context.Context, string) error
+	telegramVisibleTextDelta func(context.Context, string, string, string)
 	telegramSentOutputCount  int
 	telegramProgressTracker  *pipeline.TelegramProgressTracker
 	terminalUserMessage      string
@@ -3767,15 +3783,19 @@ func (w *desktopEventWriter) append(ctx context.Context, runID uuid.UUID, ev eve
 	}
 
 	if ev.Type == "message.delta" {
+		role, _ := ev.DataJSON["role"].(string)
+		channel, _ := ev.DataJSON["channel"].(string)
+		delta := desktopExtractDelta(ev.DataJSON)
 		if w.telegramProgressTracker != nil {
-			role, _ := ev.DataJSON["role"].(string)
-			channel, _ := ev.DataJSON["channel"].(string)
-			if delta := desktopExtractDelta(ev.DataJSON); delta != "" {
+			if delta != "" {
 				w.telegramProgressTracker.OnMessageDelta(ctx, role, channel, delta)
 			}
 		}
-		if channel, _ := ev.DataJSON["channel"].(string); channel == "" {
-			if delta := desktopExtractDelta(ev.DataJSON); delta != "" {
+		if channel == "" {
+			if delta != "" {
+				if w.telegramVisibleTextDelta != nil {
+					w.telegramVisibleTextDelta(ctx, role, channel, delta)
+				}
 				w.assistantDeltas = append(w.assistantDeltas, delta)
 				w.latestAssistantSeq = eventSeq
 				if err := w.maybeFlushResponseDraft(ctx, false); err != nil {

--- a/src/services/worker/internal/pipeline/context.go
+++ b/src/services/worker/internal/pipeline/context.go
@@ -203,6 +203,8 @@ type RunContext struct {
 	SenderIsAdmin bool
 	// TelegramToolBoundaryFlush 由 Channel 投递中间件注入：每个 tool.call 前发送尚未投递的 assistant 正文（nil 表示终态一次性投递）。
 	TelegramToolBoundaryFlush func(ctx context.Context, text string) error
+	// TelegramVisibleTextDelta 由 Channel 投递中间件注入：当 agent loop 产出可见正文 delta 时通知渠道状态。
+	TelegramVisibleTextDelta func(ctx context.Context)
 	// TelegramProgressTracker 由 Channel 投递中间件注入：按 segment 发送/编辑 Telegram 进度消息（nil 表示不启用）。
 	TelegramProgressTracker *TelegramProgressTracker
 	// TelegramStreamDeliveryRemainder 由 AgentLoopHandler 写入：分段投递模式下终态只发此尾段（已 TrimSpace）。

--- a/src/services/worker/internal/pipeline/handler_agent_loop.go
+++ b/src/services/worker/internal/pipeline/handler_agent_loop.go
@@ -96,6 +96,11 @@ func NewAgentLoopHandler(
 			pendingSubAgentCallbackIDs(rc.PendingSubAgentCallbacks),
 			IsHeartbeatRunContext(rc),
 		)
+		writer.telegramVisibleTextDelta = func(ctx context.Context, role, channel, delta string) {
+			if IsVisibleAssistantTextDelta(rc, role, channel, delta) && rc.TelegramVisibleTextDelta != nil {
+				rc.TelegramVisibleTextDelta(ctx)
+			}
+		}
 		defer writer.Close(ctx)
 		defer func() {
 			if writer.terminalRunStatus == "" {
@@ -300,6 +305,7 @@ type eventWriter struct {
 	totalCostUSD             float64
 
 	telegramToolBoundaryFlush func(context.Context, string) error
+	telegramVisibleTextDelta  func(context.Context, string, string, string)
 	telegramSentOutputCount   int
 	telegramProgressTracker   *TelegramProgressTracker
 	pendingReplyOverride      string
@@ -691,16 +697,20 @@ func (w *eventWriter) Append(
 	}
 
 	if ev.Type == "message.delta" {
+		role, _ := ev.DataJSON["role"].(string)
+		channel, _ := ev.DataJSON["channel"].(string)
+		delta := extractAssistantDelta(ev.DataJSON)
 		if w.telegramProgressTracker != nil {
-			role, _ := ev.DataJSON["role"].(string)
-			channel, _ := ev.DataJSON["channel"].(string)
-			if delta := extractAssistantDelta(ev.DataJSON); delta != "" {
+			if delta != "" {
 				w.telegramProgressTracker.OnMessageDelta(ctx, role, channel, delta)
 			}
 		}
 		// 只累积主内容，thinking channel 不计入最终消息文本
-		if channel, _ := ev.DataJSON["channel"].(string); channel == "" {
-			if delta := extractAssistantDelta(ev.DataJSON); delta != "" {
+		if channel == "" {
+			if delta != "" {
+				if w.telegramVisibleTextDelta != nil {
+					w.telegramVisibleTextDelta(ctx, role, channel, delta)
+				}
 				w.assistantDeltas = append(w.assistantDeltas, delta)
 			}
 		}

--- a/src/services/worker/internal/pipeline/handler_agent_loop_sub_agent_events_test.go
+++ b/src/services/worker/internal/pipeline/handler_agent_loop_sub_agent_events_test.go
@@ -141,6 +141,77 @@ func TestEventWriterAppend_AppendsSubAgentCancelledEventOnCancelRequest(t *testi
 	}
 }
 
+func TestEventWriterNotifiesVisibleTextDelta(t *testing.T) {
+	db := testutil.SetupPostgresDatabase(t, "arkloop_visible_text_delta_notify")
+	pool, err := pgxpool.New(context.Background(), db.DSN)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	accountID := uuid.New()
+	projectID := uuid.New()
+	threadID := uuid.New()
+	runID := uuid.New()
+	seedPipelineThread(t, pool, accountID, threadID, projectID)
+	seedPipelineRun(t, pool, accountID, threadID, runID, nil)
+
+	rc := &RunContext{}
+	writer := newEventWriter(pool, data.Run{ID: runID, AccountID: accountID, ThreadID: threadID}, "trace-visible-delta", nil, nil, nil, "", "", data.UsageRecordsRepository{}, data.CreditsRepository{}, 1000, 1, nil, nil, nil, nil, creditpolicy.DefaultPolicy, false, nil, nil, nil, "", nil, nil, false)
+	defer writer.Close(context.Background())
+
+	var visibleCalls int
+	writer.telegramVisibleTextDelta = func(_ context.Context, role, channel, delta string) {
+		if IsVisibleAssistantTextDelta(rc, role, channel, delta) {
+			visibleCalls++
+		}
+	}
+	emitter := events.NewEmitter("trace-visible-delta")
+
+	if err := writer.Append(context.Background(), data.RunsRepository{}, data.RunEventsRepository{}, runID, emitter.Emit("message.delta", map[string]any{
+		"role":          "assistant",
+		"content_delta": "hello",
+	}, nil, nil)); err != nil {
+		t.Fatalf("append visible delta: %v", err)
+	}
+	if visibleCalls != 1 {
+		t.Fatalf("expected visible callback once, got %d", visibleCalls)
+	}
+
+	if err := writer.Append(context.Background(), data.RunsRepository{}, data.RunEventsRepository{}, runID, emitter.Emit("message.delta", map[string]any{
+		"role":          "assistant",
+		"channel":       "thinking",
+		"content_delta": "hidden",
+	}, nil, nil)); err != nil {
+		t.Fatalf("append thinking delta: %v", err)
+	}
+	if visibleCalls != 1 {
+		t.Fatalf("thinking delta should not notify visible callback, got %d", visibleCalls)
+	}
+
+	rc.DiscussRun = true
+	if err := writer.Append(context.Background(), data.RunsRepository{}, data.RunEventsRepository{}, runID, emitter.Emit("message.delta", map[string]any{
+		"role":          "assistant",
+		"content_delta": "private",
+	}, nil, nil)); err != nil {
+		t.Fatalf("append private discuss delta: %v", err)
+	}
+	if visibleCalls != 1 {
+		t.Fatalf("private discuss delta should not notify visible callback, got %d", visibleCalls)
+	}
+
+	rc.DiscussTextVisible = true
+	if err := writer.Append(context.Background(), data.RunsRepository{}, data.RunEventsRepository{}, runID, emitter.Emit("message.delta", map[string]any{
+		"role":          "assistant",
+		"content_delta": "public",
+	}, nil, nil)); err != nil {
+		t.Fatalf("append visible discuss delta: %v", err)
+	}
+	if visibleCalls != 2 {
+		t.Fatalf("expected visible discuss delta to notify callback, got %d", visibleCalls)
+	}
+}
+
 func TestEventWriterAppend_AutoQueuesNextRunFromPendingInputs(t *testing.T) {
 	db := testutil.SetupPostgresDatabase(t, "arkloop_sub_agent_pending_autorun")
 	pool, err := pgxpool.New(context.Background(), db.DSN)

--- a/src/services/worker/internal/pipeline/mw_channel_delivery.go
+++ b/src/services/worker/internal/pipeline/mw_channel_delivery.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"arkloop/services/shared/onebotclient"
@@ -197,14 +198,24 @@ func NewChannelDeliveryMiddlewareWithOptions(pool *pgxpool.Pool, opts ChannelDel
 			rc.TelegramToolBoundaryFlush = streamFlush
 		}
 
-		var stopTyping context.CancelFunc
-		if preloaded != nil && ux.TypingIndicator && strings.TrimSpace(preloaded.Token) != "" && tgClient != nil && ShouldSendTelegramTypingRefresh(rc) {
-			stopTyping = StartTelegramTypingRefresh(ctx, tgClient, preloaded.Token, rc.ChannelContext.Conversation.Target)
+		var (
+			typingMu   sync.Mutex
+			stopTyping context.CancelFunc
+		)
+		if preloaded != nil && ux.TypingIndicator && strings.TrimSpace(preloaded.Token) != "" && tgClient != nil && rc != nil && rc.ChannelContext != nil {
+			rc.TelegramVisibleTextDelta = func(context.Context) {
+				typingMu.Lock()
+				defer typingMu.Unlock()
+				if stopTyping == nil {
+					stopTyping = StartTelegramTypingRefresh(ctx, tgClient, preloaded.Token, rc.ChannelContext.Conversation.Target)
+				}
+			}
 		}
 
 		err := next(ctx, rc)
 		if rc != nil {
 			rc.TelegramToolBoundaryFlush = nil
+			rc.TelegramVisibleTextDelta = nil
 			if rc.TelegramProgressTracker != nil {
 				rc.TelegramProgressTracker.Finalize(ctx)
 			}
@@ -1470,14 +1481,26 @@ func ShouldShowTelegramProgress(rc *RunContext) bool {
 	return isPrivateChannelConversation(rc.ChannelContext.ConversationType)
 }
 
-func ShouldSendTelegramTypingRefresh(rc *RunContext) bool {
-	if rc == nil || rc.ChannelContext == nil || IsHeartbeatRunContext(rc) {
+func IsVisibleAssistantTextDelta(rc *RunContext, role, channel, delta string) bool {
+	if strings.TrimSpace(delta) == "" {
 		return false
 	}
-	if isPrivateChannelConversation(rc.ChannelContext.ConversationType) {
+	if role != "" && !strings.EqualFold(strings.TrimSpace(role), "assistant") {
+		return false
+	}
+	if strings.TrimSpace(channel) != "" {
+		return false
+	}
+	if rc == nil {
 		return true
 	}
-	return rc.ChannelContext.MentionsBot || rc.ChannelContext.IsReplyToBot || rc.ChannelContext.MatchesKeyword
+	if rc.DiscussRun && !rc.DiscussTextVisible {
+		return false
+	}
+	if IsHeartbeatRunContext(rc) && (rc.HeartbeatToolOutcome == nil || !rc.HeartbeatToolOutcome.Reply) {
+		return false
+	}
+	return true
 }
 
 // StartTelegramTypingRefresh sends Telegram typing actions until cancel (about every 4s, first immediately).

--- a/src/services/worker/internal/pipeline/mw_channel_delivery_test.go
+++ b/src/services/worker/internal/pipeline/mw_channel_delivery_test.go
@@ -121,69 +121,48 @@ func TestShouldShowTelegramProgress_PrivateOnly(t *testing.T) {
 	}
 }
 
-func TestShouldSendTelegramTypingRefresh_HardTriggersOnly(t *testing.T) {
-	if ShouldSendTelegramTypingRefresh(nil) {
-		t.Fatal("nil run context should not send typing")
+func TestIsVisibleAssistantTextDelta(t *testing.T) {
+	if IsVisibleAssistantTextDelta(nil, "assistant", "", "") {
+		t.Fatal("empty delta should not be visible")
+	}
+	if IsVisibleAssistantTextDelta(nil, "tool", "", "x") {
+		t.Fatal("non-assistant role should not be visible")
+	}
+	if IsVisibleAssistantTextDelta(nil, "assistant", "thinking", "x") {
+		t.Fatal("non-text channel should not be visible")
+	}
+	if !IsVisibleAssistantTextDelta(nil, "assistant", "", "x") {
+		t.Fatal("assistant text delta should be visible without run context")
 	}
 
-	privateRC := &RunContext{
-		ChannelContext: &ChannelContext{ConversationType: "private"},
-	}
-	if !ShouldSendTelegramTypingRefresh(privateRC) {
-		t.Fatal("private conversation should send typing")
+	discussSilent := &RunContext{DiscussRun: true}
+	if IsVisibleAssistantTextDelta(discussSilent, "assistant", "", "x") {
+		t.Fatal("discuss text before visible gate should not be visible")
 	}
 
-	scheduledDiscussRC := &RunContext{
-		DiscussRun: true,
-		ChannelContext: &ChannelContext{
-			ConversationType: "supergroup",
-		},
-	}
-	if ShouldSendTelegramTypingRefresh(scheduledDiscussRC) {
-		t.Fatal("scheduled discuss should not send typing")
+	discussVisible := &RunContext{DiscussRun: true, DiscussTextVisible: true}
+	if !IsVisibleAssistantTextDelta(discussVisible, "assistant", "", "x") {
+		t.Fatal("discuss text after visible gate should be visible")
 	}
 
-	mentionRC := &RunContext{
-		DiscussRun: true,
-		ChannelContext: &ChannelContext{
-			ConversationType: "group",
-			MentionsBot:      true,
-		},
-	}
-	if !ShouldSendTelegramTypingRefresh(mentionRC) {
-		t.Fatal("group mention should send typing")
+	heartbeatSilent := &RunContext{HeartbeatRun: true}
+	if IsVisibleAssistantTextDelta(heartbeatSilent, "assistant", "", "x") {
+		t.Fatal("heartbeat text before reply decision should not be visible")
 	}
 
-	replyRC := &RunContext{
-		DiscussRun: true,
-		ChannelContext: &ChannelContext{
-			ConversationType: "group",
-			IsReplyToBot:     true,
-		},
-	}
-	if !ShouldSendTelegramTypingRefresh(replyRC) {
-		t.Fatal("group reply should send typing")
+	heartbeatPayloadSilent := &RunContext{InputJSON: map[string]any{"run_kind": "heartbeat"}}
+	if IsVisibleAssistantTextDelta(heartbeatPayloadSilent, "assistant", "", "x") {
+		t.Fatal("payload heartbeat text before reply decision should not be visible")
 	}
 
-	keywordRC := &RunContext{
-		DiscussRun: true,
-		ChannelContext: &ChannelContext{
-			ConversationType: "group",
-			MatchesKeyword:   true,
-		},
-	}
-	if !ShouldSendTelegramTypingRefresh(keywordRC) {
-		t.Fatal("group keyword should send typing")
-	}
-
-	heartbeatRC := &RunContext{
+	heartbeatReply := &RunContext{
 		HeartbeatRun: true,
-		ChannelContext: &ChannelContext{
-			ConversationType: "private",
+		HeartbeatToolOutcome: &HeartbeatDecisionOutcome{
+			Reply: true,
 		},
 	}
-	if ShouldSendTelegramTypingRefresh(heartbeatRC) {
-		t.Fatal("heartbeat should not send typing")
+	if !IsVisibleAssistantTextDelta(heartbeatReply, "assistant", "", "x") {
+		t.Fatal("heartbeat reply text should be visible")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Build & Push Images**: Replace QEMU emulation with native `ubuntu-24.04-arm` runners. Split into build (14 parallel) + merge (7 parallel) jobs with per-image-arch scoped Docker cache
- **Build Desktop**: Add Go module cache, pnpm store cache, and Electron binary cache to all build jobs

## Results (tested via `workflow_dispatch`)

| Workflow | Before | After | Change |
|----------|--------|-------|--------|
| Build & Push Images | 21 min | **2 min 20s** | **-89%** |
| Build Desktop (Phase 1) | 9m 34s | 6m 48s | -29% |
| worker Docker build | 21 min | 1m 55s | -91% |
| `pnpm install` (macOS Intel) | 1m 37s | 48s | -51% |
| Build bundled CLI (macOS Intel) | 3m 41s | 29s | -87% |

Build Desktop total wall time is gated by Apple notarization (~7 min, not optimizable).

## Test plan

- [x] `workflow_dispatch` Build & Push Images — 21/21 jobs green
- [x] `workflow_dispatch` Build Desktop — 15/15 jobs green, release correctly skipped
- [x] Multi-arch manifests verified (7/7 merge jobs success)
- [x] Artifact naming collision between `console` and `console-lite` fixed and verified