### PR TITLE
feat: stable image generation artifact display with dedup and multi-i…

### DIFF
--- a/src/apps/web/src/__tests__/agentEventProcessing.test.ts
+++ b/src/apps/web/src/__tests__/agentEventProcessing.test.ts
@@ -6,6 +6,7 @@ import {
   buildMessageSubAgentsFromAgentEvents,
   buildMessageThinkingFromAgentEvents,
   buildMessageWidgetsFromAgentEvents,
+  buildMessageGeneratedImagesFromAgentEvents,
   findAssistantMessageForRun,
   patchCodeExecutionList,
   filterUnprocessedAgentEvents,
@@ -1563,5 +1564,45 @@ describe('memory_search file result summary', () => {
 
   it('summarizes memory_edit as updated', () => {
     expect(fileOpOutputFromResult('memory_edit', { status: 'ok' })).toBe('updated')
+  })
+})
+
+describe('buildMessageGeneratedImagesFromAgentEvents', () => {
+  it('应按 toolCallIndex 和返回顺序重建 assistant message 的 generatedImages', () => {
+    const events = [
+      makeRunEvent({
+        runId: 'run_1',
+        seq: 1,
+        type: 'tool-result',
+        data: {
+          tool_name: 'image_generate',
+          tool_call_id: 'call_img_2',
+          tool_call_index: 2,
+          result: {
+            artifacts: [
+              { key: 'img-2', filename: '2.png', size: 1, mime_type: 'image/png' },
+            ],
+          },
+        },
+      }),
+      makeRunEvent({
+        runId: 'run_1',
+        seq: 2,
+        type: 'tool-result',
+        data: {
+          tool_name: 'image_generate',
+          tool_call_id: 'call_img_1',
+          tool_call_index: 1,
+          result: {
+            artifacts: [
+              { key: 'img-1', filename: '1.png', size: 1, mime_type: 'image/png' },
+              { key: 'img-1', filename: '1-dup.png', size: 1, mime_type: 'image/png' },
+            ],
+          },
+        },
+      }),
+    ]
+
+    expect(buildMessageGeneratedImagesFromAgentEvents(events).map((item) => item.artifact.key)).toEqual(['img-1', 'img-2'])
   })
 })

--- a/src/apps/web/src/__tests__/chatPageLoading.test.tsx
+++ b/src/apps/web/src/__tests__/chatPageLoading.test.tsx
@@ -42,6 +42,8 @@ import {
   readThreadRunHandoff,
   writeThreadRunHandoff,
   clearThreadRunHandoff,
+  readMessageAgentEvents,
+  writeMessageAgentEvents,
 } from '../storage'
 
 const sseMock = vi.hoisted(() => {
@@ -339,6 +341,8 @@ vi.mock('../storage', async () => {
     readThreadRunHandoff: vi.fn(() => null),
     writeThreadRunHandoff: vi.fn(),
     clearThreadRunHandoff: vi.fn(),
+    readMessageAgentEvents: vi.fn(() => null),
+    writeMessageAgentEvents: vi.fn(),
     readMessageBrowserActions: vi.fn(() => null),
     writeMessageBrowserActions: vi.fn(),
     migrateMessageMetadata: vi.fn(),
@@ -410,17 +414,37 @@ vi.mock('../components/ChatInput', () => ({
   }),
 }))
 
+vi.mock('../components/GeneratedImageGroup', () => ({
+  GeneratedImageGroup: ({
+    items,
+  }: {
+    items?: Array<{ artifact: { key: string; filename: string; mime_type: string; size: number; title?: string } }>
+  }) => (
+    <div data-testid="generated-image-group">
+      {items?.map((item) => (
+        <span key={item.artifact.key} data-testid="generated-image-item">
+          {item.artifact.filename}
+        </span>
+      ))}
+    </div>
+  ),
+}))
+
 vi.mock('../components/MessageBubble', () => ({
   MessageBubble: ({
     message,
     contentOverride,
     animateUserEnter,
     onRetry,
+    generatedImages,
+    accessToken,
   }: {
     message: { content: string; role?: string }
     contentOverride?: string
     animateUserEnter?: boolean
     onRetry?: () => void
+    generatedImages?: Array<{ artifact: { key: string; filename: string; mime_type: string; size: number; title?: string } }>
+    accessToken?: string
   }) => (
     <div className={animateUserEnter ? 'user-prompt-bubble-enter' : undefined}>
       {contentOverride ?? message.content}
@@ -428,6 +452,15 @@ vi.mock('../components/MessageBubble', () => ({
         <button type="button" aria-label="retry-user-message" onClick={onRetry}>
           retry-user
         </button>
+      )}
+      {generatedImages && generatedImages.length > 0 && accessToken && (
+        <div data-testid="generated-image-group">
+          {generatedImages.map((item) => (
+            <span key={item.artifact.key} data-testid="generated-image-item">
+              {item.artifact.filename}
+            </span>
+          ))}
+        </div>
       )}
     </div>
   ),
@@ -938,6 +971,7 @@ describe('ChatPage loading state', () => {
   const mockedReadThreadRunHandoff = vi.mocked(readThreadRunHandoff)
   const mockedWriteThreadRunHandoff = vi.mocked(writeThreadRunHandoff)
   const mockedClearThreadRunHandoff = vi.mocked(clearThreadRunHandoff)
+  const mockedReadMessageAgentEvents = vi.mocked(readMessageAgentEvents)
   const actEnvironment = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
   const originalActEnvironment = actEnvironment.IS_REACT_ACT_ENVIRONMENT
   const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
@@ -966,6 +1000,7 @@ describe('ChatPage loading state', () => {
     mockedReadThreadWorkFolder.mockReturnValue(null)
     mockedReadThreadThinkingEnabled.mockReturnValue('off')
     mockedReadThreadRunHandoff.mockReturnValue(null)
+    mockedReadMessageAgentEvents.mockReturnValue(null)
     actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
     HTMLElement.prototype.scrollIntoView = vi.fn()
     sseMock.state = 'idle'
@@ -6373,6 +6408,95 @@ describe('ChatPage loading state', () => {
         html: '<svg><text>ok</text></svg>',
       },
     ])
+
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  it('hasAssistantTurn=true 时 GeneratedImageGroup 只出现一次', async () => {
+    const imageArtifact = {
+      key: 'img-key-1',
+      filename: 'generated.png',
+      size: 1024,
+      mime_type: 'image/png',
+    }
+
+    mockedListMessages.mockResolvedValue([
+      {
+        id: 'msg-user',
+        role: 'user',
+        content: 'generate an image',
+        account_id: 'acc-1',
+        thread_id: 'thread-1',
+        created_by_user_id: 'user-1',
+        created_at: '2026-03-10T00:00:00Z',
+      },
+      {
+        id: 'msg-assistant',
+        role: 'assistant',
+        content: 'Here is your image',
+        run_id: 'run-1',
+        account_id: 'acc-1',
+        thread_id: 'thread-1',
+        created_by_user_id: 'user-1',
+        created_at: '2026-03-10T00:00:01Z',
+      },
+    ])
+
+    mockedReadMessageAssistantTurn.mockImplementation((messageId: string) =>
+      messageId === 'msg-assistant'
+        ? { segments: [{ type: 'text', content: 'Here is your image' }] }
+        : null,
+    )
+
+    mockedReadMessageAgentEvents.mockImplementation((messageId: string) =>
+      messageId === 'msg-assistant'
+        ? [
+            {
+              id: 'evt-1',
+              streamId: 'run-1',
+              order: 1,
+              timestamp: '2026-03-10T00:00:01Z',
+              type: 'tool-result' as const,
+              toolName: 'image_generate',
+              data: {
+                toolCallId: 'tc-1',
+                toolCallIndex: 0,
+                output: { artifacts: [imageArtifact] },
+              },
+            },
+          ]
+        : null,
+    )
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(
+        <LocaleProvider>
+          <MemoryRouter initialEntries={['/t/thread-1']}>
+            <Routes>
+              <Route element={<OutletShell context={buildOutletContext()} />}>
+                <Route path="/t/:threadId" element={<ChatPage />} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </LocaleProvider>,
+      )
+      await flushMicrotasks()
+      await flushMicrotasks()
+    })
+
+    const groups = container.querySelectorAll('[data-testid="generated-image-group"]')
+    expect(groups.length).toBe(1)
+
+    const items = container.querySelectorAll('[data-testid="generated-image-item"]')
+    expect(items.length).toBe(1)
+    expect(items[0].textContent).toBe('generated.png')
 
     act(() => {
       root.unmount()

--- a/src/apps/web/src/__tests__/generatedImages.test.ts
+++ b/src/apps/web/src/__tests__/generatedImages.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentUIEvent } from '../agent-ui'
+import {
+  appendGeneratedImages,
+  buildGeneratedImagesFromAgentEvents,
+  generatedImageKeySet,
+  type GeneratedImageItem,
+} from '../generatedImages'
+
+function makeToolResultEvent(params: {
+  seq: number
+  toolCallId: string
+  toolCallIndex?: number
+  toolName?: string
+  artifacts: Array<{
+    key: string
+    filename: string
+    mime_type: string
+    size?: number
+    title?: string
+    display?: 'inline' | 'panel'
+  }>
+}): AgentUIEvent {
+  return {
+    id: `evt_${params.seq}`,
+    streamId: 'run_1',
+    order: params.seq,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    type: 'tool-result',
+    toolName: params.toolName ?? 'image_generate',
+    data: {
+      toolCallId: params.toolCallId,
+      toolCallIndex: params.toolCallIndex ?? params.seq,
+      toolName: params.toolName ?? 'image_generate',
+      output: { artifacts: params.artifacts },
+    },
+  }
+}
+
+describe('appendGeneratedImages', () => {
+  it('同一 tool call 返回多张图片时应完整保留并按返回顺序排列', () => {
+    const next = appendGeneratedImages([], {
+      toolCallId: 'call_img_1',
+      toolCallIndex: 3,
+      artifacts: [
+        { key: 'img-1', filename: '1.png', size: 1, mime_type: 'image/png' },
+        { key: 'img-2', filename: '2.png', size: 1, mime_type: 'image/png' },
+      ],
+    })
+
+    expect(next.map((item) => item.artifact.key)).toEqual(['img-1', 'img-2'])
+    expect(next.map((item) => item.order)).toEqual([0, 1])
+  })
+
+  it('同一消息内重复 key 应只保留第一次出现', () => {
+    const initial: GeneratedImageItem[] = [{
+      artifact: { key: 'img-1', filename: '1.png', size: 1, mime_type: 'image/png' },
+      toolCallId: 'call_img_1',
+      toolCallIndex: 1,
+      order: 0,
+    }]
+
+    const next = appendGeneratedImages(initial, {
+      toolCallId: 'call_img_2',
+      toolCallIndex: 2,
+      artifacts: [
+        { key: 'img-1', filename: '1-copy.png', size: 1, mime_type: 'image/png' },
+        { key: 'img-3', filename: '3.png', size: 1, mime_type: 'image/png' },
+      ],
+    })
+
+    expect(next.map((item) => item.artifact.key)).toEqual(['img-1', 'img-3'])
+  })
+})
+
+describe('buildGeneratedImagesFromAgentEvents', () => {
+  it('只应从 image_generate 的图片 artifact 重建 generatedImages', () => {
+    const events = [
+      makeToolResultEvent({
+        seq: 1,
+        toolCallId: 'call_img_1',
+        artifacts: [
+          { key: 'img-1', filename: '1.png', size: 1, mime_type: 'image/png' },
+          { key: 'doc-1', filename: 'notes.md', size: 1, mime_type: 'text/markdown' },
+        ],
+      }),
+      makeToolResultEvent({
+        seq: 2,
+        toolCallId: 'call_art_1',
+        toolName: 'create_artifact',
+        artifacts: [
+          { key: 'img-2', filename: 'chart.png', size: 1, mime_type: 'image/png' },
+        ],
+      }),
+      makeToolResultEvent({
+        seq: 3,
+        toolCallId: 'call_img_1',
+        artifacts: [
+          { key: 'img-3', filename: '3.png', size: 1, mime_type: 'image/png' },
+        ],
+      }),
+    ]
+
+    const result = buildGeneratedImagesFromAgentEvents(events)
+
+    expect(result.map((item) => item.artifact.key)).toEqual(['img-1', 'img-3'])
+    expect(generatedImageKeySet(result)).toEqual(new Set(['img-1', 'img-3']))
+  })
+})

--- a/src/apps/web/src/__tests__/markdownRenderer.test.tsx
+++ b/src/apps/web/src/__tests__/markdownRenderer.test.tsx
@@ -14,6 +14,7 @@ function renderMarkdown(content: string, options?: {
   accessToken?: string
   runId?: string
   artifacts?: ArtifactRef[]
+  suppressedArtifactKeys?: Set<string>
   compact?: boolean
   typography?: 'default' | 'work'
   onOpenResource?: (resource: ResourceRef, options?: { trigger?: HTMLElement | null; artifacts?: ArtifactRef[]; runId?: string }) => void
@@ -28,6 +29,7 @@ function renderMarkdown(content: string, options?: {
         accessToken={options?.accessToken}
         runId={options?.runId}
         artifacts={options?.artifacts}
+        suppressedArtifactKeys={options?.suppressedArtifactKeys}
         compact={options?.compact}
         typography={options?.typography}
         onOpenResource={options?.onOpenResource}
@@ -563,5 +565,57 @@ describe('MarkdownRenderer', () => {
     // 通过检查渲染结果包含正常的表格结构来验证（无 || 崩坏）
     expect(html).not.toContain('||')
     expect(html).not.toContain('---------|')
+  })
+
+  it('对已在结构化图片区展示过的图片 artifact 不应再次渲染 markdown 图片', () => {
+    const html = renderMarkdown('![图 1](artifact:img-1)', {
+      accessToken: 'token',
+      artifacts: [{
+        key: 'img-1',
+        filename: '1.png',
+        size: 1,
+        mime_type: 'image/png',
+        title: '图 1',
+      }],
+      suppressedArtifactKeys: new Set(['img-1']),
+    })
+
+    // 已被 suppressedArtifactKeys 覆盖的图片不应渲染
+    expect(html).not.toContain('height:200px')
+  })
+
+  it('不应抑制未在结构化图片区展示的图片 artifact', () => {
+    const html = renderMarkdown('![图 2](artifact:img-2)', {
+      accessToken: 'token',
+      artifacts: [{
+        key: 'img-2',
+        filename: '2.png',
+        size: 1,
+        mime_type: 'image/png',
+        title: '图 2',
+      }],
+    })
+
+    // 未被 suppressed 的图片应正常渲染
+    expect(html).toContain('height:200px')
+  })
+
+  it('不应抑制非图片 artifact 链接', () => {
+    const html = renderMarkdown('[文档](artifact:doc-1)', {
+      accessToken: 'token',
+      artifacts: [{
+        key: 'doc-1',
+        filename: 'notes.md',
+        size: 1,
+        mime_type: 'text/markdown',
+        title: 'notes',
+      }],
+      suppressedArtifactKeys: new Set(['doc-1']),
+      onOpenResource: () => {},
+    })
+
+    // 非图片 artifact 即使 key 在 suppressedArtifactKeys 中也应正常渲染
+    expect(html).toContain('document-resource-card')
+    expect(html).toContain('文档')
   })
 })

--- a/src/apps/web/src/agent-ui/event-data.ts
+++ b/src/apps/web/src/agent-ui/event-data.ts
@@ -216,6 +216,9 @@ export function normalizeAgentEventData(params: {
     case 'tool-result':
       return {
         toolCallId: stringField(record, 'toolCallId', 'tool_call_id') ?? eventId,
+        ...(numberField(record, 'toolCallIndex', 'tool_call_index') != null
+          ? { toolCallIndex: numberField(record, 'toolCallIndex', 'tool_call_index') }
+          : {}),
         ...(normalizeToolName(record, toolName) ? { toolName: normalizeToolName(record, toolName) } : {}),
         output: record && 'output' in record ? record.output : record?.result,
         ...(normalizeToolError(record?.error, errorCode)

--- a/src/apps/web/src/agentEventProcessing.ts
+++ b/src/apps/web/src/agentEventProcessing.ts
@@ -1585,6 +1585,12 @@ export function buildMessageWebFetchesFromAgentEvents(events: AgentUIEvent[]): W
   return fetches
 }
 
+export {
+  buildGeneratedImagesFromAgentEvents as buildMessageGeneratedImagesFromAgentEvents,
+  generatedImageKeySet,
+  type GeneratedImageItem,
+} from './generatedImages'
+
 export function buildTodosFromAgentEvents(
   events: AgentUIEvent[],
 ): Array<{ id: string; content: string; activeForm?: string; status: string }> {

--- a/src/apps/web/src/components/ChatView.tsx
+++ b/src/apps/web/src/components/ChatView.tsx
@@ -66,6 +66,7 @@ import {
 } from '../assistantTurnSegments'
 import { copTimelinePayloadForSegment, toolCallIdsInCopTimelines } from '../copSegmentTimeline'
 import { buildResolvedPool, EMPTY_POOL, buildFallbackSegments } from '../copSubSegment'
+import { buildMessageGeneratedImagesFromAgentEvents } from '../agentEventProcessing'
 import { applyAgentEventToWebSearchSteps } from '../webSearchTimelineFromAgentEvent'
 import { useLocale } from '../contexts/LocaleContext'
 import { useAuth } from '../contexts/auth'
@@ -1576,6 +1577,14 @@ export const ChatView = memo(function ChatView() {
         searchStepsMap.forEach((searchSteps, id) => mergeMeta(id, { searchSteps }))
         assistantTurnMap.forEach((assistantTurn, id) => mergeMeta(id, { assistantTurn }))
         agentEventsMap.forEach((agentEvents, id) => mergeMeta(id, { agentEvents }))
+        // Rebuild generatedImages from persisted agent events so history replay
+        // shows the same images as the live SSE phase.
+        for (const [id, agentEvents] of agentEventsMap) {
+          const generatedImages = buildMessageGeneratedImagesFromAgentEvents(agentEvents)
+          if (generatedImages.length > 0) {
+            mergeMeta(id, { generatedImages })
+          }
+        }
         failedErrorMap.forEach((failedError, id) => mergeMeta(id, { failedError }))
         const metaBatch = Array.from(metaEntries.entries())
         primeMetaBatch(metaBatch)
@@ -3130,7 +3139,15 @@ export const ChatView = memo(function ChatView() {
     [streamingArtifacts, livePlacedShowWidgetCallIds],
   )
   const visibleStreamingArtifacts = useMemo(
-    () => streamingArtifacts.filter((e) => e.toolName === 'create_artifact' && e.content && e.display !== 'panel' && (!e.toolCallId || !livePlacedCreateArtifactCallIds.has(e.toolCallId))),
+    () => streamingArtifacts.filter((e) => {
+      if (e.display === 'panel') return false
+      if (e.toolName === 'create_artifact') {
+        return !!e.content && (!e.toolCallId || !livePlacedCreateArtifactCallIds.has(e.toolCallId))
+      }
+      // image_generate artifacts are now handled via generatedImages
+      // (rendered inside the message bubble via GeneratedImageGroup).
+      return false
+    }),
     [streamingArtifacts, livePlacedCreateArtifactCallIds],
   )
   const visibleStreamingWidgetsSignature = useMemo(() => JSON.stringify(

--- a/src/apps/web/src/components/GeneratedImageGroup.tsx
+++ b/src/apps/web/src/components/GeneratedImageGroup.tsx
@@ -1,0 +1,24 @@
+import { ArtifactImage } from './ArtifactImage'
+import type { GeneratedImageItem } from '../generatedImages'
+
+export function GeneratedImageGroup({
+  items,
+  accessToken,
+}: {
+  items?: GeneratedImageItem[]
+  accessToken?: string
+}) {
+  if (!items || items.length === 0 || !accessToken) return null
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '8px' }}>
+      {items.map((item) => (
+        <ArtifactImage
+          key={item.artifact.key}
+          artifact={item.artifact}
+          accessToken={accessToken}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/apps/web/src/components/MarkdownRenderer.tsx
+++ b/src/apps/web/src/components/MarkdownRenderer.tsx
@@ -44,6 +44,7 @@ type ArtifactsContextValue = {
   onOpenDocument?: (artifact: ArtifactRef, options?: { trigger?: HTMLElement | null; artifacts?: ArtifactRef[]; runId?: string }) => void
   onOpenResource?: (resource: ResourceRef, options?: { trigger?: HTMLElement | null; artifacts?: ArtifactRef[]; runId?: string }) => void
   activePanelArtifactKey?: string | null
+  suppressedArtifactKeys?: Set<string>
 }
 
 const ArtifactsContext = createContext<ArtifactsContextValue>({ artifacts: [], accessToken: '' })
@@ -345,7 +346,7 @@ function ResourceDocumentCard({
 
 // artifact: 协议感知的 img 渲染器
 function ArtifactAwareImg({ src, alt }: { src?: string; alt?: string }) {
-  const { artifacts, accessToken, runId, workFolder, onOpenDocument, onOpenResource, activePanelArtifactKey } = useContext(ArtifactsContext)
+  const { artifacts, accessToken, runId, workFolder, onOpenDocument, onOpenResource, activePanelArtifactKey, suppressedArtifactKeys } = useContext(ArtifactsContext)
   const [failed, setFailed] = useState(false)
 
   if (src?.startsWith(ARTIFACT_URI_PREFIX)) {
@@ -355,6 +356,7 @@ function ArtifactAwareImg({ src, alt }: { src?: string; alt?: string }) {
     if (!artifact || !accessToken) return null
 
     if (artifact.mime_type.startsWith('image/')) {
+      if (suppressedArtifactKeys?.has(artifact.key)) return null
       return <ArtifactImage artifact={artifact} accessToken={accessToken} />
     }
     if (artifact.mime_type === 'text/html') {
@@ -425,7 +427,7 @@ function ArtifactAwareImg({ src, alt }: { src?: string; alt?: string }) {
 
 // artifact: 协议感知的 a 渲染器
 function ArtifactAwareLink({ href, children }: { href?: string; children?: ReactNode }) {
-  const { artifacts, accessToken, runId, workFolder, onOpenDocument, onOpenResource, activePanelArtifactKey } = useContext(ArtifactsContext)
+  const { artifacts, accessToken, runId, workFolder, onOpenDocument, onOpenResource, activePanelArtifactKey, suppressedArtifactKeys } = useContext(ArtifactsContext)
 
   if (href?.startsWith(BROWSER_URI_PREFIX) && !onOpenResource) {
     return <>{children}</>
@@ -439,6 +441,7 @@ function ArtifactAwareLink({ href, children }: { href?: string; children?: React
 
     // LLM 可能用 [text](artifact:key) 而非 ![text](artifact:key)，统一按 mime_type 分派
     if (artifact.mime_type.startsWith('image/')) {
+      if (suppressedArtifactKeys?.has(artifact.key)) return null
       return <ArtifactImage artifact={artifact} accessToken={accessToken} />
     }
     if (artifact.mime_type === 'text/html') {
@@ -936,6 +939,7 @@ type Props = {
   streaming?: boolean
   webSources?: WebSource[]
   artifacts?: ArtifactRef[]
+  suppressedArtifactKeys?: Set<string>
   accessToken?: string
   runId?: string
   workFolder?: string | null
@@ -948,7 +952,7 @@ type Props = {
   allowHtml?: boolean
 }
 
-export const MarkdownRenderer = memo(function MarkdownRenderer({ content, disableMath, streaming = false, webSources, artifacts, accessToken, runId, workFolder, onOpenDocument, onOpenResource, compact = false, typography = 'default', trimTrailingMargin = false, allowHtml = false }: Props) {
+export const MarkdownRenderer = memo(function MarkdownRenderer({ content, disableMath, streaming = false, webSources, artifacts, suppressedArtifactKeys, accessToken, runId, workFolder, onOpenDocument, onOpenResource, compact = false, typography = 'default', trimTrailingMargin = false, allowHtml = false }: Props) {
   const sourceCount = webSources?.length ?? 0
   const artifactCount = artifacts?.length ?? 0
   const shouldThrottleStreamingMath = streaming && !disableMath && containsLikelyMath(content)
@@ -1005,7 +1009,8 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, disabl
     onOpenDocument,
     onOpenResource,
     activePanelArtifactKey,
-  }), [accessToken, artifacts, onOpenDocument, onOpenResource, runId, workFolder, activePanelArtifactKey])
+    suppressedArtifactKeys,
+  }), [accessToken, artifacts, onOpenDocument, onOpenResource, runId, workFolder, activePanelArtifactKey, suppressedArtifactKeys])
 
   const normalizedContent = useMemo(() => {
     const withArtifactLinks = preprocessBareArtifactRefs(renderContent, artifacts ?? [])

--- a/src/apps/web/src/components/MessageBubble.tsx
+++ b/src/apps/web/src/components/MessageBubble.tsx
@@ -8,6 +8,7 @@ import type { ArtifactAction } from './ArtifactIframe'
 import { memo } from 'react'
 import { useTypewriter } from '../hooks/useTypewriter'
 import type { ResourceRef } from './resource-preview/types'
+import type { GeneratedImageItem } from '../generatedImages'
 
 type Props = {
   message: AgentMessage
@@ -22,6 +23,7 @@ type Props = {
   shareState?: 'idle' | 'sharing' | 'shared'
   webSources?: WebSource[]
   artifacts?: ArtifactRef[]
+  generatedImages?: GeneratedImageItem[]
   browserActions?: BrowserActionRef[]
   widgets?: WidgetRef[]
   accessToken?: string
@@ -39,7 +41,7 @@ type Props = {
   suppressActionBar?: boolean
 }
 
-export const MessageBubble = memo(function MessageBubble({ message, streamAssistantMarkdown, animateUserEnter, onUserEnterAnimationEnd, onRetry, onEdit, onFork, onShare, shareState, webSources, artifacts, browserActions, widgets, accessToken, workFolder, onWidgetAction, onShowSources, onOpenDocument, onOpenResource, onViewRunDetail, contentPrefix, contentOverride, plainTextForCopy, isLast, isWorkMode, suppressActionBar }: Props) {
+export const MessageBubble = memo(function MessageBubble({ message, streamAssistantMarkdown, animateUserEnter, onUserEnterAnimationEnd, onRetry, onEdit, onFork, onShare, shareState, webSources, artifacts, generatedImages, browserActions, widgets, accessToken, workFolder, onWidgetAction, onShowSources, onOpenDocument, onOpenResource, onViewRunDetail, contentPrefix, contentOverride, plainTextForCopy, isLast, isWorkMode, suppressActionBar }: Props) {
   if (message.role === 'user') {
     return (
       <UserMessage
@@ -63,6 +65,7 @@ export const MessageBubble = memo(function MessageBubble({ message, streamAssist
       shareState={shareState}
       webSources={webSources}
       artifacts={artifacts}
+      generatedImages={generatedImages}
       browserActions={browserActions}
       widgets={widgets}
       accessToken={accessToken}

--- a/src/apps/web/src/components/MessageList.tsx
+++ b/src/apps/web/src/components/MessageList.tsx
@@ -5,6 +5,8 @@ import { CopSegmentBlocks } from './CopSegmentBlocks'
 import { TopLevelCopToolBlock } from './TopLevelCopToolBlock'
 import { AssistantActionBar } from './messagebubble/AssistantMessage'
 import { MarkdownRenderer } from './MarkdownRenderer'
+import { GeneratedImageGroup } from './GeneratedImageGroup'
+import { generatedImageKeySet } from '../generatedImages'
 import { WidgetBlock } from './WidgetBlock'
 import { IncognitoDivider } from './IncognitoDivider'
 import { useLocale } from '../contexts/LocaleContext'
@@ -312,6 +314,11 @@ export const MessageList = memo(forwardRef<MessageListHandle, MessageListProps>(
     if (hideTerminalRunMessage) return null
 
     const msgMeta = msg.role === 'assistant' ? meta.getMeta(msg.id) : undefined
+    const effectiveGeneratedImages =
+      msg.role === 'assistant' && idx === messages.length - 1 && isStreaming
+        ? stream.liveGeneratedImages
+        : msgMeta?.generatedImages
+    const suppressedArtifactKeys = generatedImageKeySet(effectiveGeneratedImages ?? [])
     const resolvedSources = msg.role === 'assistant' ? resolvedMessageSources.get(msg.id) : undefined
     const isCurrentTerminalRunMessage =
       msg.role === 'assistant' &&
@@ -393,6 +400,7 @@ export const MessageList = memo(forwardRef<MessageListHandle, MessageListProps>(
                       content={seg.content}
                       webSources={resolvedSources}
                       artifacts={msgMeta?.artifacts}
+                      suppressedArtifactKeys={suppressedArtifactKeys}
                       accessToken={accessToken}
                       runId={msg.streamId ?? undefined}
                       workFolder={workFolder}
@@ -480,6 +488,7 @@ export const MessageList = memo(forwardRef<MessageListHandle, MessageListProps>(
                         content={workGroupSplit.finalText}
                         webSources={resolvedSources}
                         artifacts={msgMeta?.artifacts}
+                        suppressedArtifactKeys={suppressedArtifactKeys}
                         accessToken={accessToken}
                         runId={msg.streamId ?? undefined}
                         workFolder={workFolder}
@@ -497,6 +506,9 @@ export const MessageList = memo(forwardRef<MessageListHandle, MessageListProps>(
                 renderSegment(seg, si, historicalSegments, currentRunMessageLive && si === historicalSegments.length - 1)
               )
             })()}
+          {effectiveGeneratedImages && effectiveGeneratedImages.length > 0 && (
+            <GeneratedImageGroup items={effectiveGeneratedImages} accessToken={accessToken} />
+          )}
           {idx === messages.length - 1 && !isStreaming && !sending && (
             <AssistantActionBar
               textToCopy={assistantTurnPlainText(historicalTurn!)}
@@ -565,6 +577,7 @@ export const MessageList = memo(forwardRef<MessageListHandle, MessageListProps>(
           }
           webSources={resolvedSources}
           artifacts={msg.role === 'assistant' ? msgMeta?.artifacts : undefined}
+          generatedImages={msg.role === 'assistant' && hasAssistantTurn ? undefined : effectiveGeneratedImages}
           browserActions={msg.role === 'assistant' ? msgMeta?.browserActions : undefined}
           widgets={bubbleWidgets}
           accessToken={accessToken}

--- a/src/apps/web/src/components/messagebubble/AssistantMessage.tsx
+++ b/src/apps/web/src/components/messagebubble/AssistantMessage.tsx
@@ -4,6 +4,8 @@ import type { AgentMessage } from '../../agent-ui'
 import type { WebSource, ArtifactRef, BrowserActionRef, WidgetRef } from '../../storage'
 import { WidgetBlock } from '../WidgetBlock'
 import { MarkdownRenderer } from '../MarkdownRenderer'
+import { GeneratedImageGroup } from '../GeneratedImageGroup'
+import { generatedImageKeySet, type GeneratedImageItem } from '../../generatedImages'
 import { recordPerfCount, recordPerfValue } from '../../perfDebug'
 import { BrowserScreenshotCard } from '../BrowserScreenshotCard'
 import type { ArtifactAction } from '../ArtifactIframe'
@@ -25,6 +27,7 @@ type Props = {
   shareState?: 'idle' | 'sharing' | 'shared'
   webSources?: WebSource[]
   artifacts?: ArtifactRef[]
+  generatedImages?: GeneratedImageItem[]
   browserActions?: BrowserActionRef[]
   widgets?: WidgetRef[]
   accessToken?: string
@@ -208,6 +211,7 @@ export const AssistantMessage = memo(function AssistantMessage({
   shareState,
   webSources,
   artifacts,
+  generatedImages,
   browserActions,
   widgets,
   accessToken,
@@ -225,6 +229,7 @@ export const AssistantMessage = memo(function AssistantMessage({
   suppressActionBar,
 }: Props) {
   const messageText = messageTextContent(message)
+  const suppressedArtifactKeys = generatedImageKeySet(generatedImages ?? [])
   const renderedContent = contentOverride ?? (contentPrefix && messageText.startsWith(contentPrefix) ? messageText.slice(contentPrefix.length).trimStart() : messageText)
   const textForCopy = plainTextForCopy ?? renderedContent
   const displayedAssistantMd = useTypewriter(renderedContent, !streamMarkdown)
@@ -266,6 +271,7 @@ export const AssistantMessage = memo(function AssistantMessage({
             streaming={streamMarkdown}
             webSources={webSources}
             artifacts={artifacts}
+            suppressedArtifactKeys={suppressedArtifactKeys}
             accessToken={accessToken}
             runId={message.streamId}
             workFolder={workFolder}
@@ -275,6 +281,7 @@ export const AssistantMessage = memo(function AssistantMessage({
             trimTrailingMargin
           />
         </div>
+        <GeneratedImageGroup items={generatedImages} accessToken={accessToken} />
         {!suppressActionBar && (
           <AssistantActionBar
             textToCopy={textForCopy}

--- a/src/apps/web/src/contexts/message-meta.tsx
+++ b/src/apps/web/src/contexts/message-meta.tsx
@@ -53,10 +53,13 @@ import {
 } from '../storage'
 import type { AssistantTurnUi } from '../assistantTurnSegments'
 import type { AppError } from '@arkloop/shared'
+import type { GeneratedImageItem } from '../generatedImages'
+import { buildGeneratedImagesFromAgentEvents } from '../generatedImages'
 
 export type MessageMeta = {
   sources?: WebSource[]
   artifacts?: ArtifactRef[]
+  generatedImages?: GeneratedImageItem[]
   codeExecutions?: CodeExecutionRef[]
   browserActions?: BrowserActionRef[]
   subAgents?: SubAgentRef[]
@@ -233,7 +236,11 @@ export function MessageMetaProvider({ children }: { children: ReactNode }) {
       const widgets = readMessageWidgets(id)
       if (widgets) meta.widgets = widgets
       const agentEvents = readMessageAgentEvents(id)
-      if (agentEvents) meta.agentEvents = agentEvents
+      if (agentEvents) {
+        meta.agentEvents = agentEvents
+        const generatedImages = buildGeneratedImagesFromAgentEvents(agentEvents)
+        if (generatedImages.length > 0) meta.generatedImages = generatedImages
+      }
       const coveredRunIds = readMessageCoveredRunIds(id)
       if (coveredRunIds) meta.coveredRunIds = coveredRunIds
       if (Object.keys(meta).length > 0) entries.push([id, meta])
@@ -342,6 +349,10 @@ export function MessageMetaProvider({ children }: { children: ReactNode }) {
       if (agentEvents.length > 0) {
         writeMessageAgentEvents(messageId, agentEvents)
         meta.agentEvents = agentEvents
+        const generatedImages = buildGeneratedImagesFromAgentEvents(agentEvents)
+        if (generatedImages.length > 0) {
+          meta.generatedImages = generatedImages
+        }
       }
 
       if (Object.keys(meta).length > 0) {

--- a/src/apps/web/src/contexts/stream.tsx
+++ b/src/apps/web/src/contexts/stream.tsx
@@ -23,6 +23,7 @@ import {
   snapshotAssistantTurn,
 } from '../assistantTurnSegments'
 import type { AgentUIEvent } from '../agent-ui'
+import type { GeneratedImageItem } from '../generatedImages'
 
 export type Segment = {
   segmentId: string
@@ -47,6 +48,8 @@ interface StreamContextValue {
   liveAssistantTurn: AssistantTurnUi | null
   preserveLiveRunUi: boolean
   workTodos: Array<{ id: string; content: string; activeForm?: string; status: string }>
+  liveGeneratedImages: GeneratedImageItem[]
+  liveGeneratedImagesRef: React.RefObject<GeneratedImageItem[]>
 
   // internal refs (双写：SSE 热路径先写 ref，渲染时 flush)
   segmentsRef: React.RefObject<Segment[]>
@@ -74,6 +77,7 @@ interface StreamContextValue {
   setWorkTodos: React.Dispatch<React.SetStateAction<Array<{ id: string; content: string; activeForm?: string; status: string }>>>
   setPreserveLiveRunUi: (v: boolean) => void
   setLiveAssistantTurn: React.Dispatch<React.SetStateAction<AssistantTurnUi | null>>
+  setLiveGeneratedImages: React.Dispatch<React.SetStateAction<GeneratedImageItem[]>>
   requestAssistantTurnThinkingBreak: () => void
   releaseCompletedHandoffToHistory: () => void
   resetSearchSteps: () => void
@@ -144,6 +148,7 @@ export function StreamProvider({ children }: { children: ReactNode }) {
   const [liveAssistantTurn, setLiveAssistantTurn] = useState<AssistantTurnUi | null>(null)
   const [preserveLiveRunUi, setPreserveLiveRunUiState] = useState(false)
   const [workTodos, setWorkTodos] = useState<Array<{ id: string; content: string; activeForm?: string; status: string }>>([])
+  const [liveGeneratedImages, setLiveGeneratedImages] = useState<GeneratedImageItem[]>([])
 
   const segmentsRef = useRef<Segment[]>([])
   useEffect(() => { segmentsRef.current = segments }, [segments])
@@ -156,6 +161,8 @@ export function StreamProvider({ children }: { children: ReactNode }) {
   const streamingArtifactsRef = useRef<StreamingArtifactEntry[]>([])
   const activeSegmentIdRef = useRef<string | null>(null)
   const assistantTurnFoldStateRef = useRef<AssistantTurnFoldState>(createEmptyAssistantTurnFoldState())
+  const liveGeneratedImagesRef = useRef<GeneratedImageItem[]>([])
+  useEffect(() => { liveGeneratedImagesRef.current = liveGeneratedImages }, [liveGeneratedImages])
   const bumpPendingRef = useRef(false)
   const bumpRafRef = useRef<number | null>(null)
 
@@ -227,6 +234,8 @@ export function StreamProvider({ children }: { children: ReactNode }) {
     setLiveAssistantTurn(null)
     setPreserveLiveRunUiState(false)
     setWorkTodos([])
+    setLiveGeneratedImages([])
+    liveGeneratedImagesRef.current = []
   }, [])
 
   const requestAssistantTurnThinkingBreakAction = useCallback(() => {
@@ -247,6 +256,8 @@ export function StreamProvider({ children }: { children: ReactNode }) {
     setTopLevelWebFetches([])
     streamingArtifactsRef.current = []
     setStreamingArtifacts([])
+    setLiveGeneratedImages([])
+    liveGeneratedImagesRef.current = []
   }, [])
 
   const resetSearchSteps = useCallback(() => {
@@ -294,6 +305,8 @@ export function StreamProvider({ children }: { children: ReactNode }) {
     liveAssistantTurn,
     preserveLiveRunUi,
     workTodos,
+    liveGeneratedImages,
+    liveGeneratedImagesRef,
     segmentsRef,
     searchStepsRef,
     streamingArtifactsRef,
@@ -318,6 +331,7 @@ export function StreamProvider({ children }: { children: ReactNode }) {
     setWorkTodos,
     setPreserveLiveRunUi,
     setLiveAssistantTurn,
+    setLiveGeneratedImages,
     requestAssistantTurnThinkingBreak: requestAssistantTurnThinkingBreakAction,
     releaseCompletedHandoffToHistory,
     resetSearchSteps,
@@ -338,6 +352,7 @@ export function StreamProvider({ children }: { children: ReactNode }) {
     liveAssistantTurn,
     preserveLiveRunUi,
     workTodos,
+    liveGeneratedImages,
     addTopLevelCodeExecution,
     addTopLevelSubAgent,
     addTopLevelFileOp,

--- a/src/apps/web/src/generatedImages.ts
+++ b/src/apps/web/src/generatedImages.ts
@@ -1,0 +1,85 @@
+import { canonicalToolName } from '@arkloop/shared'
+import type { AgentUIEvent } from './agent-ui'
+import { agentEventDataRecord, agentEventToolOutput } from './agent-ui/event-data'
+import { IMAGE_GENERATE_TOOL_NAME } from './copSubSegment'
+import type { ArtifactRef } from './storage'
+
+export type GeneratedImageItem = {
+  artifact: ArtifactRef
+  toolCallId?: string
+  toolCallIndex: number
+  order: number
+}
+
+type AppendGeneratedImagesArgs = {
+  toolCallId?: string
+  toolCallIndex?: number
+  artifacts: ArtifactRef[]
+}
+
+function isImageArtifact(artifact: ArtifactRef): boolean {
+  return artifact.mime_type.startsWith('image/')
+}
+
+function extractArtifacts(result: unknown): ArtifactRef[] {
+  if (!result || typeof result !== 'object') return []
+  const artifacts = (result as { artifacts?: unknown[] }).artifacts
+  if (!Array.isArray(artifacts)) return []
+  return artifacts
+    .filter((item): item is Record<string, unknown> => !!item && typeof item === 'object')
+    .filter((item) => typeof item.key === 'string' && typeof item.filename === 'string')
+    .map((item) => ({
+      key: item.key as string,
+      filename: item.filename as string,
+      size: typeof item.size === 'number' ? item.size : 0,
+      mime_type: typeof item.mime_type === 'string' ? item.mime_type : '',
+      title: typeof item.title === 'string' ? item.title : undefined,
+      display: item.display === 'panel' ? 'panel' : item.display === 'inline' ? 'inline' : undefined,
+    }))
+}
+
+export function appendGeneratedImages(
+  prev: GeneratedImageItem[],
+  args: AppendGeneratedImagesArgs,
+): GeneratedImageItem[] {
+  const seen = new Set(prev.map((item) => item.artifact.key))
+  const additions: GeneratedImageItem[] = []
+  let order = 0
+
+  for (const artifact of args.artifacts) {
+    if (!isImageArtifact(artifact)) continue
+    if (seen.has(artifact.key)) continue
+    seen.add(artifact.key)
+    additions.push({
+      artifact,
+      toolCallId: args.toolCallId,
+      toolCallIndex: args.toolCallIndex ?? Number.MAX_SAFE_INTEGER,
+      order,
+    })
+    order += 1
+  }
+
+  return [...prev, ...additions].sort((left, right) => {
+    if (left.toolCallIndex !== right.toolCallIndex) return left.toolCallIndex - right.toolCallIndex
+    return left.order - right.order
+  })
+}
+
+export function buildGeneratedImagesFromAgentEvents(events: AgentUIEvent[]): GeneratedImageItem[] {
+  let items: GeneratedImageItem[] = []
+  for (const event of events) {
+    if (event.type !== 'tool-result') continue
+    if (canonicalToolName(event.toolName ?? '') !== IMAGE_GENERATE_TOOL_NAME) continue
+    const data = agentEventDataRecord(event.data)
+    items = appendGeneratedImages(items, {
+      toolCallId: typeof data?.toolCallId === 'string' ? data.toolCallId : undefined,
+      toolCallIndex: typeof data?.toolCallIndex === 'number' ? data.toolCallIndex : event.order,
+      artifacts: extractArtifacts(agentEventToolOutput(event.data)),
+    })
+  }
+  return items
+}
+
+export function generatedImageKeySet(items: GeneratedImageItem[]): Set<string> {
+  return new Set(items.map((item) => item.artifact.key))
+}

--- a/src/apps/web/src/hooks/useThreadSseEffect.ts
+++ b/src/apps/web/src/hooks/useThreadSseEffect.ts
@@ -58,6 +58,8 @@ import {
   agentEventToolOutput,
   type AgentMessage,
 } from '../agent-ui'
+import { IMAGE_GENERATE_TOOL_NAME } from '../copSubSegment'
+import { appendGeneratedImages } from '../generatedImages'
 
 function isUnauthorizedStreamError(error: unknown): boolean {
   return !!error && typeof error === 'object' && (error as { status?: unknown }).status === 401
@@ -129,6 +131,8 @@ export function useThreadSseEffect({
     resetSearchSteps,
     setStreamingArtifacts,
     streamingArtifactsRef,
+    liveGeneratedImagesRef,
+    setLiveGeneratedImages,
     setSegments,
     segmentsRef,
     activeSegmentIdRef,
@@ -277,6 +281,8 @@ export function useThreadSseEffect({
         liveSegmentSnapshotIdsRef.current.clear()
         streamingArtifactsRef.current = []
         setStreamingArtifacts([])
+        liveGeneratedImagesRef.current = []
+        setLiveGeneratedImages([])
         flushSegmentsRefToState()
         resetAssistantTurnLive()
         activeSegmentIdRef.current = null
@@ -659,6 +665,17 @@ export function useThreadSseEffect({
               }
             }
             setStreamingArtifacts([...streamingArtifactsRef.current])
+          }
+          if (resultToolName === IMAGE_GENERATE_TOOL_NAME) {
+            const callId = typeof obj?.toolCallId === 'string' ? obj.toolCallId : undefined
+            const callIndex = typeof obj?.toolCallIndex === 'number' ? obj.toolCallIndex : event.order
+            const nextImages = appendGeneratedImages(liveGeneratedImagesRef.current, {
+              toolCallId: callId,
+              toolCallIndex: callIndex,
+              artifacts: newArtifacts,
+            })
+            liveGeneratedImagesRef.current = nextImages
+            setLiveGeneratedImages(nextImages)
           }
         }
         if (resultToolName === 'python_execute' || resultToolName === 'exec_command' || resultToolName === 'continue_process' || resultToolName === 'terminate_process' || resultToolName === 'document_write' || resultToolName === 'create_artifact' || resultToolName === 'browser' || isWebFetchToolName(resultToolName)) {


### PR DESCRIPTION
…mage support

Replace single artifactRef with generatedImages data model to handle multiple images per image_generate call without overwriting. Images render via GeneratedImageGroup in the assistant turn path, with markdown suppression via suppressedArtifactKeys to prevent duplicates.

Fix: when hasAssistantTurn=true, skip passing generatedImages to MessageBubble to avoid double rendering in both segment and bubble paths.