### PR TITLE
fix: include toolCallID in image_generate artifact key to prevent ove…

### DIFF
--- a/src/services/worker/internal/tools/builtin/image_generate/executor.go
+++ b/src/services/worker/internal/tools/builtin/image_generate/executor.go
@@ -54,7 +54,7 @@ func (e *ToolExecutor) Execute(
 	_ string,
 	args map[string]any,
 	execCtx tools.ExecutionContext,
-	_ string,
+	toolCallID string,
 ) tools.ExecutionResult {
 	started := time.Now()
 	if e == nil || e.store == nil {
@@ -107,7 +107,7 @@ func (e *ToolExecutor) Execute(
 
 	contentType := normalizeImageContentType(image.MimeType, image.Bytes)
 	filename := defaultGeneratedImageName + fileExtForContentType(contentType)
-	key := buildArtifactKey(execCtx, filename)
+	key := buildArtifactKey(execCtx, toolCallID, filename)
 	var threadID *string
 	if execCtx.ThreadID != nil {
 		value := execCtx.ThreadID.String()
@@ -217,12 +217,12 @@ func splitModelSelector(selector string) (string, string, bool) {
 	return credentialName, modelName, true
 }
 
-func buildArtifactKey(execCtx tools.ExecutionContext, filename string) string {
+func buildArtifactKey(execCtx tools.ExecutionContext, toolCallID string, filename string) string {
 	accountID := "_anonymous"
 	if execCtx.AccountID != nil {
 		accountID = execCtx.AccountID.String()
 	}
-	return filepath.ToSlash(fmt.Sprintf("%s/%s/%s", accountID, execCtx.RunID.String(), filename))
+	return filepath.ToSlash(fmt.Sprintf("%s/%s/%s/%s", accountID, execCtx.RunID.String(), toolCallID, filename))
 }
 
 func (e *ToolExecutor) loadInputImages(ctx context.Context, args map[string]any, accountID uuid.UUID) ([]llm.ContentPart, error) {

--- a/src/services/worker/internal/tools/builtin/image_generate/executor_test.go
+++ b/src/services/worker/internal/tools/builtin/image_generate/executor_test.go
@@ -139,7 +139,7 @@ func TestToolExecutorExecuteWritesArtifact(t *testing.T) {
 	if result.Error != nil {
 		t.Fatalf("unexpected error: %#v", result.Error)
 	}
-	if store.key != accountID.String()+"/"+runID.String()+"/generated-image.png" {
+	if store.key != accountID.String()+"/"+runID.String()+"/call_1/generated-image.png" {
 		t.Fatalf("unexpected artifact key: %s", store.key)
 	}
 	if store.options.ContentType != "image/png" {


### PR DESCRIPTION
…rwrites

Multiple image_generate calls within the same run produced identical artifact keys (accountID/runID/generated-image.png), causing later calls to overwrite earlier images. Add toolCallID to the key path so each call produces a unique artifact key.