### PR TITLE
fix(web): support drag-and-drop of multiple files into chat

### DIFF
--- a/src/apps/web/src/components/chat-input/AttachmentCard.tsx
+++ b/src/apps/web/src/components/chat-input/AttachmentCard.tsx
@@ -22,7 +22,7 @@ export function hasTransferFiles(dataTransfer?: DataTransfer | null): boolean {
 export function extractFilesFromTransfer(dataTransfer?: DataTransfer | null): File[] {
   if (!dataTransfer) return []
   const files: File[] = []
-  const seenTypes = new Set<string>()
+  const seen = new Set<string>()
 
   const items = Array.from(dataTransfer.items ?? [])
 
@@ -38,11 +38,9 @@ export function extractFilesFromTransfer(dataTransfer?: DataTransfer | null): Fi
 
   if (allFiles.length > 0) {
     for (const file of allFiles) {
-      const prefix = file.type.split('/')[0]
-      if (prefix === 'image') {
-        if (seenTypes.has('image')) continue
-        seenTypes.add('image')
-      }
+      const key = `${file.name}|${file.size}|${file.lastModified}`
+      if (seen.has(key)) continue
+      seen.add(key)
       files.push(file)
     }
     return files
@@ -53,10 +51,11 @@ export function extractFilesFromTransfer(dataTransfer?: DataTransfer | null): Fi
   // This handles cases where the clipboard image kind check passes but file is null.
   for (const item of items) {
     if (!item.type.startsWith('image/')) continue
-    if (seenTypes.has('image')) continue
     const file = item.getAsFile()
     if (file) {
-      seenTypes.add('image')
+      const key = `${file.name}|${file.size}|${file.lastModified}`
+      if (seen.has(key)) continue
+      seen.add(key)
       files.push(file)
     }
   }


### PR DESCRIPTION
The dedup logic in extractFilesFromTransfer was keyed by MIME type prefix ('image'), so only one image file survived each drop. Switch to identity-based dedup (name|size|lastModified) so that truly distinct files all pass through while still suppressing genuine duplicates from Electron clipboard bugs.