### PR TITLE
fix(image_generate,resource_copy): add fallback for attachment key mi…

### DIFF
--- a/src/services/worker/internal/tools/builtin/image_generate/executor.go
+++ b/src/services/worker/internal/tools/builtin/image_generate/executor.go
@@ -27,11 +27,12 @@ const (
 )
 
 type ToolExecutor struct {
-	store         objectstore.Store
-	db            workerdata.QueryDB
-	config        sharedconfig.Resolver
-	routingLoader *routing.ConfigLoader
-	generate      func(context.Context, llm.ResolvedGatewayConfig, llm.ImageGenerationRequest) (llm.GeneratedImage, error)
+	store                 objectstore.Store
+	messageAttachmentStore objectstore.Store
+	db                    workerdata.QueryDB
+	config                sharedconfig.Resolver
+	routingLoader         *routing.ConfigLoader
+	generate              func(context.Context, llm.ResolvedGatewayConfig, llm.ImageGenerationRequest) (llm.GeneratedImage, error)
 }
 
 func NewToolExecutor(
@@ -47,6 +48,11 @@ func NewToolExecutor(
 		routingLoader: routingLoader,
 		generate:      llm.GenerateImageWithResolvedConfig,
 	}
+}
+
+func (e *ToolExecutor) WithMessageAttachmentStore(s objectstore.Store) *ToolExecutor {
+	e.messageAttachmentStore = s
+	return e
 }
 
 func (e *ToolExecutor) Execute(
@@ -251,6 +257,12 @@ func (e *ToolExecutor) loadInputImages(ctx context.Context, args map[string]any,
 			return nil, fmt.Errorf("input_images[%d] is outside the current account", idx)
 		}
 		data, contentType, err := e.store.GetWithContentType(ctx, key)
+		if err != nil && e.messageAttachmentStore != nil {
+			data, contentType, err = e.messageAttachmentStore.GetWithContentType(ctx, key)
+		}
+		if err != nil && e.messageAttachmentStore != nil && !strings.HasPrefix(key, "attachments/") {
+			data, contentType, err = e.messageAttachmentStore.GetWithContentType(ctx, "attachments/"+key)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("input_images[%d] not found", idx)
 		}

--- a/src/services/worker/internal/tools/builtin/resource_copy/executor.go
+++ b/src/services/worker/internal/tools/builtin/resource_copy/executor.go
@@ -123,6 +123,9 @@ func authorizeObjectKey(ctx context.Context, store objectstore.Store, key string
 		return nil
 	}
 	info, err := store.Head(ctx, key)
+	if err != nil && objectstore.IsNotFound(err) && attachment && !strings.HasPrefix(key, "attachments/") {
+		info, err = store.Head(ctx, "attachments/"+key)
+	}
 	if err != nil {
 		return &tools.ExecutionError{ErrorClass: errorFetchFailed, Message: fmt.Sprintf("read resource metadata failed: %s", err.Error())}
 	}


### PR DESCRIPTION
…ssing attachments/ prefix

When the LLM constructs an attachment key without the leading attachments/ prefix (e.g. <accountID>/<msgID>/<file> instead of attachments/<accountID>/<msgID>/<file>), both image_generate and resource_copy fail because the actual filesystem path includes the prefix.

- image_generate loadInputImages: after artifact and attachment store lookups fail, retry with attachments/ prefix if missing
- resource_copy authorizeObjectKey: after Head() returns not-found, retry with attachments/ prefix if key lacks it
- Also adds messageAttachmentStore field + WithMessageAttachmentStore to ToolExecutor (was missing on current main branch)